### PR TITLE
feat(links): add softplus link as alternative to log (#363)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # bmm 1.3.1
 
+### New features
+* Add `softplus` as an opt-in link function for positively-bounded parameters, as an alternative to the default `log` link. `softplus(x) = log(1 + exp(x))` keeps parameters positive while growing linearly for large values, avoiding the numerical blow-up of `exp()` and giving predictor effects an additive (rather than multiplicative) interpretation on the natural scale. Enable it per parameter via the model's `links` list, e.g. `m3(...)$links <- list(c = "softplus", a = "softplus")` or `ddm(rt, response, links = list(bound = "softplus"))` (#363).
+
 ### Bug fixes
 * Fix `swald_lccdf()` returning incorrect log-survival probability when response time equals non-decision time in the **cswald** model. Previously returned `-Inf` instead of `0` (log of survival = 1) (#348).
 

--- a/R/bmmformula.R
+++ b/R/bmmformula.R
@@ -442,18 +442,19 @@ apply_links.formula <- function(formula, links = nlist()) {
 #' The inverse of a specified link function applied to a parameter.
 #'
 #' @param par A character string representing the parameter to which the inverse link function will be applied.
-#' @param link A character string specifying the link function. Options are "log", "logit", "probit", and "identity".
+#' @param link A character string specifying the link function. Options are "log", "softplus", "logit", "probit", and "identity".
 #' @return An expression representing the inverse link function applied to the parameter.
 #' @examples
 #' inv_link("x", "log")
 #' identical(inv_link("x", "log"), quote(exp(x))) # TRUE
 #' @noRd
-inv_link <- function(par = character(0), link = c("log", "logit", "probit", "identity")) {
+inv_link <- function(par = character(0), link = c("log", "softplus", "logit", "probit", "identity")) {
   stopifnot(is.character(par), length(par) == 1)
   par <- as.symbol(par)
   link <- match.arg(link)
   switch(link,
     log = substitute(exp(par)),
+    softplus = substitute(log1p_exp(par)),
     logit = substitute(inv_logit(par)),
     probit = substitute(Phi(par)),
     identity = par

--- a/R/helpers-parameters.R
+++ b/R/helpers-parameters.R
@@ -73,7 +73,7 @@ c_bessel2sqrtexp <- function(c, kappa) {
 #'
 #' @param values A numerical vector of values the transformation should be applied to
 #' @param link A character specifying the link to be applied.
-#' Available options are: "identity", "log", "log1p", "logm1", "inverse", "sqrt", "logit", "probit", "tan_half", and "cloglog".
+#' Available options are: "identity", "log", "softplus", "log1p", "logm1", "inverse", "sqrt", "logit", "probit", "tan_half", and "cloglog".
 #' @param inverse A Boolean value indicating if values should be transformed from the native to
 #' the parameter scale (FALSE), or from the parameter scale to the native scale (TRUE)
 #'
@@ -88,6 +88,7 @@ link_transform <- function(values, link, inverse = FALSE) {
       link,
       identity = values,
       log = exp(values),
+      softplus = log1p(exp(values)),
       log1p = expm1(values),
       logm1 = brms::expp1(values),
       inverse = 1 / values,
@@ -104,6 +105,7 @@ link_transform <- function(values, link, inverse = FALSE) {
       link,
       identity = values,
       log = log(values),
+      softplus = log(expm1(values)),
       log1p = log1p(values),
       logm1 = brms::logm1(values),
       inverse = 1 / values,

--- a/R/model_cswald.R
+++ b/R/model_cswald.R
@@ -123,7 +123,9 @@
 #' @param links A named list of link functions for the model parameters.
 #'   Available parameters depend on the version: "simple" has `drift`, `bound`,
 #'   `ndt`, and `s`; "crisk" additionally has `zr`. Default links are "log" for
-#'   most parameters and "logit" for `zr`.
+#'   most parameters and "logit" for `zr`. For positive parameters, "softplus"
+#'   is available as an alternative to "log" that grows linearly for large
+#'   values and avoids the numerical blow-up of `exp()`.
 #' @param version A character string specifying which version of the cswald
 #'   model to use. Options are:
 #'   \itemize{

--- a/R/model_ddm.R
+++ b/R/model_ddm.R
@@ -71,7 +71,10 @@
 #' @details `r model_info(.model_ddm())`
 #' @param rt Name of the reaction time variable coding reaction time in seconds in the data.
 #' @param response Name of the response variable coding the response numerically (0 = lower response / incorrect, 1 = upper response / correct)
-#' @param links A list of links for the parameters.
+#' @param links A list of links for the parameters. For positive parameters
+#'   (e.g. `bound`, `ndt`), "softplus" is available as an alternative to the
+#'   default "log" link that grows linearly for large values and avoids the
+#'   numerical blow-up of `exp()`.
 #' @section Default behavior:
 #' By default, `zr` is fixed at 0. If you want to estimate `zr`, add a formula
 #' for `zr` in your `bmf()` call.

--- a/R/model_ezdm.R
+++ b/R/model_ezdm.R
@@ -104,7 +104,10 @@
 #' @param var_rt The names of the variable or variables (for 4par version) coding the variance of the reaction time in seconds in the data
 #' @param n_upper The name of the variable coding the number of responses that hit the upper response threshold (typically the number of correct responses) in the data.
 #' @param n_trials The name of the variable coding the number of trials that was used to calculated the aggregated statistics.
-#' @param links A list of links for the parameters.
+#' @param links A list of links for the parameters. For positive parameters
+#'   (e.g. `bound`, `ndt`), "softplus" is available as an alternative to the
+#'   default "log" link that grows linearly for large values and avoids the
+#'   numerical blow-up of `exp()`.
 #' @param version A character label for the version of the model. There is a three-parameter version
 #'   (version = "3par") of the `ezdm` that fixes the relative starting point `zr` to 0.5, and a
 #'   four parameter version (version = "4par"), that allows to freely estimate the starting point.

--- a/R/model_m3.R
+++ b/R/model_m3.R
@@ -235,6 +235,7 @@ check_model.m3_custom <- function(model, data = NULL, formula = NULL) {
     if (model$other_vars$choice_rule == "simple") {
       switch(model$links[[m]],
              log = list(main = "normal(1, 1)", effects = "normal(0, 0.5)"),
+             softplus = list(main = "normal(2, 1)", effects = "normal(0, 0.5)"),
              identity = list(main = "normal(10, 4)", effects = "normal(0, 0.5)"),
              logit = list(main = "logistic(0, 1)", effects = "normal(0, 0.5)"),
              stop2("Invalid link function provided! Please use one of the following link functions: identity, log, softplus, logit")
@@ -242,6 +243,7 @@ check_model.m3_custom <- function(model, data = NULL, formula = NULL) {
     } else if (model$other_vars$choice_rule == "softmax") {
       switch(model$links[[m]],
              log = list(main = "normal(0, 1)", effects = "normal(0, 0.5)"),
+             softplus = list(main = "normal(1, 1)", effects = "normal(0, 0.5)"),
              identity = list(main = "normal(3, 1)", effects = "normal(0, 0.5)"),
              logit = list(main = "logistic(0, 1)", effects = "normal(0, 0.5)"),
              stop2("Invalid link function provided! Please use one of the following link functions: identity, log, softplus, logit")

--- a/R/model_m3.R
+++ b/R/model_m3.R
@@ -235,16 +235,18 @@ check_model.m3_custom <- function(model, data = NULL, formula = NULL) {
     if (model$other_vars$choice_rule == "simple") {
       switch(model$links[[m]],
              log = list(main = "normal(1, 1)", effects = "normal(0, 0.5)"),
+             softplus = list(main = "normal(2, 1)", effects = "normal(0, 0.5)"),
              identity = list(main = "normal(10, 4)", effects = "normal(0, 1)"),
              logit = list(main = "logistic(0, 1)", effects = "normal(0, 0.5)"),
-             stop2("Invalid link function provided! Please use one of the following link functions: identity, log, logit")
+             stop2("Invalid link function provided! Please use one of the following link functions: identity, log, softplus, logit")
       )
     } else if (model$other_vars$choice_rule == "softmax") {
       switch(model$links[[m]],
              log = list(main = "normal(0, 1)", effects = "normal(0, 0.5)"),
+             softplus = list(main = "normal(1, 1)", effects = "normal(0, 0.5)"),
              identity = list(main = "normal(1, 1)", effects = "normal(0, 1)"),
              logit = list(main = "logistic(0, 1)", effects = "normal(0, 0.5)"),
-             stop2("Invalid link function provided! Please use one of the following link functions: identity, log, logit")
+             stop2("Invalid link function provided! Please use one of the following link functions: identity, log, softplus, logit")
       )
     }
   })

--- a/man/cswald.Rd
+++ b/man/cswald.Rd
@@ -19,7 +19,9 @@ automatically.}
 \item{links}{A named list of link functions for the model parameters.
 Available parameters depend on the version: "simple" has \code{drift}, \code{bound},
 \code{ndt}, and \code{s}; "crisk" additionally has \code{zr}. Default links are "log" for
-most parameters and "logit" for \code{zr}.}
+most parameters and "logit" for \code{zr}. For positive parameters, "softplus"
+is available as an alternative to "log" that grows linearly for large
+values and avoids the numerical blow-up of \code{exp()}.}
 
 \item{version}{A character string specifying which version of the cswald
 model to use. Options are:

--- a/man/ddm.Rd
+++ b/man/ddm.Rd
@@ -11,7 +11,10 @@ ddm(rt, response, links = NULL, ...)
 
 \item{response}{Name of the response variable coding the response numerically (0 = lower response / incorrect, 1 = upper response / correct)}
 
-\item{links}{A list of links for the parameters.}
+\item{links}{A list of links for the parameters. For positive parameters
+(e.g. \code{bound}, \code{ndt}), "softplus" is available as an alternative to the
+default "log" link that grows linearly for large values and avoids the
+numerical blow-up of \code{exp()}.}
 
 \item{...}{used internally for testing, ignore it}
 }

--- a/man/ezdm.Rd
+++ b/man/ezdm.Rd
@@ -15,7 +15,10 @@ ezdm(mean_rt, var_rt, n_upper, n_trials, links = NULL, version = "3par", ...)
 
 \item{n_trials}{The name of the variable coding the number of trials that was used to calculated the aggregated statistics.}
 
-\item{links}{A list of links for the parameters.}
+\item{links}{A list of links for the parameters. For positive parameters
+(e.g. \code{bound}, \code{ndt}), "softplus" is available as an alternative to the
+default "log" link that grows linearly for large values and avoids the
+numerical blow-up of \code{exp()}.}
 
 \item{version}{A character label for the version of the model. There is a three-parameter version
 (version = "3par") of the \code{ezdm} that fixes the relative starting point \code{zr} to 0.5, and a

--- a/tests/testthat/test-helpers-formula.R
+++ b/tests/testthat/test-helpers-formula.R
@@ -323,6 +323,17 @@ test_that("apply_links works when parameter appears in to parts of a formula", {
   expect_equal(reform, bmf(x ~ log(Phi(a)^exp(c)) + exp(c)^2, kappa ~ 1, a ~ 1, c ~ 1))
 })
 
+test_that("apply_links applies softplus link via log1p_exp", {
+  form <- bmf(x ~ a + c, kappa ~ 1, a ~ 1, c ~ 1)
+  links <- list(a = "softplus", c = "log")
+  reform <- apply_links(form, links)
+  expect_equal(reform, bmf(x ~ log1p_exp(a) + exp(c), kappa ~ 1, a ~ 1, c ~ 1))
+})
+
+test_that("inv_link maps softplus to log1p_exp", {
+  expect_identical(inv_link("x", "softplus"), quote(log1p_exp(x)))
+})
+
 test_that("apply_links gives error when unknown link type is given", {
   form <- bmf(x ~ log(a^c) + c^2, kappa ~ 1, a ~ 1, c ~ 1)
   links <- list(a = "probit", c = "logggg")

--- a/tests/testthat/test-helpers-init.R
+++ b/tests/testthat/test-helpers-init.R
@@ -440,6 +440,7 @@ test_that("create_initfun handles a softplus link override on a positive paramet
 
   expect_type(inits, "list")
   expect_true(all(sapply(inits, function(x) all(is.finite(x)))))
+})
 
 # -----------------------------------------------------------------------------
 # match_stan_to_model_par tests (substring collision scenarios)

--- a/tests/testthat/test-helpers-init.R
+++ b/tests/testthat/test-helpers-init.R
@@ -424,3 +424,20 @@ test_that("initfun output matches standata dimensions for no-intercept models", 
     )
   }
 })
+
+# =============================================================================
+# SOFTPLUS LINK (opt-in alternative to log for positive parameters)
+# =============================================================================
+
+test_that("create_initfun handles a softplus link override on a positive parameter", {
+  ff <- bmmformula(kappa ~ 1, c ~ 1)
+  dat <- oberauer_lin_2017
+  mod <- sdm(resp_error = "dev_rad", links = list(kappa = "softplus"))
+  config_args <- configure_model(mod, data = dat, formula = ff)
+
+  init_fun <- create_initfun(mod, dat, config_args$formula)
+  inits <- init_fun()
+
+  expect_type(inits, "list")
+  expect_true(all(sapply(inits, function(x) all(is.finite(x)))))
+})

--- a/tests/testthat/test-helpers-parameters.R
+++ b/tests/testthat/test-helpers-parameters.R
@@ -59,6 +59,20 @@ test_that("log and inverse log round-trip on positive values", {
   expect_equal(back, x, tolerance = 1e-12)
 })
 
+test_that("softplus and inverse softplus round-trip on positive values", {
+  x <- c(0.5, 2, 5)
+  eta <- link_transform(x, "softplus", inverse = FALSE)
+  back <- link_transform(eta, "softplus", inverse = TRUE)
+  expect_equal(back, x, tolerance = 1e-12)
+})
+
+test_that("softplus inverse maps reals to positive values", {
+  eta <- c(-5, -1, 0, 2, 10)
+  x <- link_transform(eta, "softplus", inverse = TRUE)
+  expect_true(all(is.finite(x)))
+  expect_true(all(x > 0))
+})
+
 test_that("log1p and inverse expm1 round-trip for x > -1", {
   x <- c(-0.5, -0.1, 0, 0.3, 5)
   eta <- link_transform(x, "log1p", inverse = FALSE)

--- a/tests/testthat/test-model_m3.R
+++ b/tests/testthat/test-model_m3.R
@@ -217,6 +217,43 @@ test_that("m3 compiles for the custom model / softmax choice rule", {
 })
 
 
+test_that("m3 custom accepts softplus links and generates default priors", {
+  formula <- bmf(
+    corr ~ b + a + c,
+    other ~ b + a,
+    npl ~ b,
+    c ~ 1,
+    a ~ 1
+  )
+
+  softplus_main <- list(simple = "normal(2, 1)", softmax = "normal(1, 1)")
+
+  for (rule in c("simple", "softmax")) {
+    my_model <- m3(
+      resp_cats = c("corr", "other", "npl"),
+      num_options = c(1, 2, 5),
+      choice_rule = rule,
+      links = list(c = "softplus", a = "softplus")
+    )
+
+    fit <- suppressWarnings(bmm(
+      formula = formula,
+      data = oberauer_lewandowsky_2019_e1,
+      model = my_model,
+      backend = "mock",
+      mock_fit = 1,
+      rename = F
+    ))
+
+    for (par in c("c", "a")) {
+      expect_equal(
+        fit$bmm$model$default_priors[[par]],
+        list(main = softplus_main[[rule]], effects = "normal(0, 0.5)")
+      )
+    }
+  }
+})
+
 test_that("m3 works with num_options as a numeric vector", {
   formula <- bmf(
     c ~ 1 + (1 | ID),


### PR DESCRIPTION
## Summary

Adds `softplus` as an **opt-in link function** for positively-bounded parameters, as an alternative to the default `log` link. Closes #363.

`softplus(x) = log(1 + exp(x))` maps ℝ → (0, ∞) and:
- grows **linearly** for large `x` (no `exp()` overflow), so predictor effects act *additively* on the natural scale rather than multiplicatively;
- → 0⁺ as `x → −∞`, preserving positivity.

Inverse (link): `softplus⁻¹(y) = log(expm1(y))`. Stan inverse-link: `log1p_exp(x)`.

## Changes

- **`inv_link()`** (`R/bmmformula.R`) — accepts `"softplus"`, returning `log1p_exp(par)` (standard Stan math, substituted verbatim into the formula).  Gates Path A (M3 nlf transformation).
- **`link_transform()`** (`R/helpers-parameters.R`) — adds the `softplus` case to both branches: forward `log(expm1(v))`, inverse `log1p(exp(v))`. This single shared change unblocks **init generation** for both link paths (Path A formula
  transform and Path B brms `custom_family(links=)`).
- **Docs** — updated `@param link`/`@param links` roxygen on `inv_link`, `link_transform`, and the `ddm`, `cswald`, and `ezdm` constructors; regenerated man pages.
- **NEWS** — added a *New features* bullet.

## How to use

Softplus is opt-in via a model's `links` list:

```r
# M3 (formula-transform path)
m <- m3(...)
m$links <- list(c = "softplus", a = "softplus")

# decision models (brms custom_family path — no model-file changes needed)
ddm(rt = "rt", response = "response", links = list(bound = "softplus"))
