### PR TITLE
fix(m3): recalibrate default priors for comparable choice rules and fair c vs a tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 ### Other changes
 * The **ddm** model supports both `cmdstanr` and `rstan` backends. Previously, `cmdstanr` was required.
+* Recalibrated the default priors for the **m3** activation parameters (`a`, `c`) so that the `simple` and `softmax` choice rules imply a comparable, broad prior-predictive range of average performance, and so that the `softmax` defaults place equal prior means on general (`a`) and context (`c`) activation — centering the implied `c - a` prior at zero for fair comparisons under cell-means coding. The mis-scaled `normal(0, 2)` effect prior on `c` is replaced by the shared `normal(0, 0.5)`. Because the `simple` rule requires `c > a` to predict accurate recall, its defaults remain asymmetric; direct comparisons of context and general activation should use the `softmax` choice rule (#364).
 
 # bmm 1.3.0
 

--- a/R/model_m3.R
+++ b/R/model_m3.R
@@ -15,12 +15,12 @@
     ),
     priors = list(
       simple = list(
-        a = list(main = "normal(1,0.5)", effects = "normal(0,0.5)"),
-        c = list(main = "normal(1.5,0.5)", effects = "normal(0,0.5)")
+        a = list(main = "normal(0,1)", effects = "normal(0,0.5)"),
+        c = list(main = "normal(3,1)", effects = "normal(0,0.5)")
       ),
       softmax = list(
-        a = list(main = "normal(2,1)", effects = "normal(0,0.5)"),
-        c = list(main = "normal(3,1)", effects = "normal(0,2)")
+        a = list(main = "normal(3,1)", effects = "normal(0,0.5)"),
+        c = list(main = "normal(3,1)", effects = "normal(0,0.5)")
       )
     )
   ),
@@ -36,13 +36,13 @@
     ),
     priors = list(
       simple = list(
-        a = list(main = "normal(1,0.5)", effects = "normal(0,.5)"),
-        c = list(main = "normal(1.5,0.5)", effects = "normal(0,.5)"),
+        a = list(main = "normal(0,1)", effects = "normal(0,0.5)"),
+        c = list(main = "normal(3,1)", effects = "normal(0,0.5)"),
         f = list(main = "logistic(0,1)", effects = "normal(0,1)")
       ),
       softmax = list(
         a = list(main = "normal(3,1)", effects = "normal(0,0.5)"),
-        c = list(main = "normal(3,1)", effects = "normal(0,2)"),
+        c = list(main = "normal(3,1)", effects = "normal(0,0.5)"),
         f = list(main = "logistic(0,1)", effects = "normal(0,1)")
       )
     )
@@ -235,14 +235,14 @@ check_model.m3_custom <- function(model, data = NULL, formula = NULL) {
     if (model$other_vars$choice_rule == "simple") {
       switch(model$links[[m]],
              log = list(main = "normal(1, 1)", effects = "normal(0, 0.5)"),
-             identity = list(main = "normal(10, 4)", effects = "normal(0, 1)"),
+             identity = list(main = "normal(10, 4)", effects = "normal(0, 0.5)"),
              logit = list(main = "logistic(0, 1)", effects = "normal(0, 0.5)"),
              stop2("Invalid link function provided! Please use one of the following link functions: identity, log, logit")
       )
     } else if (model$other_vars$choice_rule == "softmax") {
       switch(model$links[[m]],
              log = list(main = "normal(0, 1)", effects = "normal(0, 0.5)"),
-             identity = list(main = "normal(1, 1)", effects = "normal(0, 1)"),
+             identity = list(main = "normal(3, 1)", effects = "normal(0, 0.5)"),
              logit = list(main = "logistic(0, 1)", effects = "normal(0, 0.5)"),
              stop2("Invalid link function provided! Please use one of the following link functions: identity, log, logit")
       )

--- a/man/m3.Rd
+++ b/man/m3.Rd
@@ -75,13 +75,13 @@ decision task.
 \itemize{
 \item \code{a}:
 \itemize{
-\item \code{main}: normal(2,1)
+\item \code{main}: normal(3,1)
 \item \code{effects}: normal(0,0.5)
 }
 \item \code{c}:
 \itemize{
 \item \code{main}: normal(3,1)
-\item \code{effects}: normal(0,2)
+\item \code{effects}: normal(0,0.5)
 }
 }
 }
@@ -121,7 +121,7 @@ decision task.
 \item \code{c}:
 \itemize{
 \item \code{main}: normal(3,1)
-\item \code{effects}: normal(0,2)
+\item \code{effects}: normal(0,0.5)
 }
 \item \code{f}:
 \itemize{

--- a/tests/testthat/test-model_m3.R
+++ b/tests/testthat/test-model_m3.R
@@ -314,3 +314,30 @@ test_that("m3 with numerical vector as num_options containing 0 returns error", 
     rename = F
   ), "not identified")
 })
+
+test_that("softmax default priors give a and c equal main means (c - a centered at 0)", {
+  for (v in c("ss", "cs")) {
+    p <- m3(
+      resp_cats = if (v == "ss") c("corr", "other", "npl") else
+        c("corr", "dist_context", "other", "dist_other", "npl"),
+      num_options = if (v == "ss") c(1, 2, 3) else c(1, 2, 2, 2, 3),
+      choice_rule = "softmax", version = v
+    )$default_priors
+    expect_identical(p$a$main, p$c$main)
+  }
+})
+
+test_that("no activation effect prior is wider than the shared normal(0,0.5)", {
+  for (v in c("ss", "cs")) {
+    for (cr in c("simple", "softmax")) {
+      p <- m3(
+        resp_cats = if (v == "ss") c("corr", "other", "npl") else
+          c("corr", "dist_context", "other", "dist_other", "npl"),
+        num_options = if (v == "ss") c(1, 2, 3) else c(1, 2, 2, 2, 3),
+        choice_rule = cr, version = v
+      )$default_priors
+      expect_identical(p$a$effects, "normal(0,0.5)")
+      expect_identical(p$c$effects, "normal(0,0.5)")
+    }
+  }
+})

--- a/vignettes/articles/bmm_m3.Rmd
+++ b/vignettes/articles/bmm_m3.Rmd
@@ -106,6 +106,8 @@ $$
 
 This choice rule can be interpreted as an n-alternative SDT model over the different response candidates with a Gumbel (or double-exponential) noise distribution.
 
+The two choice rules differ in how they translate the activation sources into probabilities, and this has a consequence for comparing activation sources. The default priors for the predefined `ss` and `cs` versions are calibrated so that both rules imply a comparable, broad range of average performance. For the `softmax` rule the priors for general (`a`) and context (`c`) activation share the same mean, so the implied prior on their difference is centered at zero. This makes `softmax` the appropriate choice rule when you want to compare or test activation sources against each other directly (e.g., whether context activation exceeds general activation). The `simple` rule normalizes the raw activations, so context activation has to exceed general activation (`c > a`) for the model to predict accurate recall; its default priors therefore encode `c > a` and are not suited for directly comparing `c` and `a`. If your research question concerns the contrast between activation sources, use the `softmax` choice rule (or supply your own symmetric priors).
+
 Finally, the model then links the response frequencies $Y$ for each response category to the probabilities $p$ using a multinomial distribution with the total number of trials:
 
 $$


### PR DESCRIPTION
- softmax: equal prior means for a and c (a, c ~ normal(3,1)) so the implied
  c - a prior is centered at 0 under cell-means coding
- simple: a ~ normal(0,1), c ~ normal(3,1), calibrated to match the softmax
  prior predictive on the representative ss design (the simple rule normalizes
  raw activations, so c > a is required for realistic accuracy)
- replace the mis-scaled normal(0,2) effect prior on c with the shared
  normal(0,0.5); harmonize the custom-version fallback identity priors
- document that direct comparisons of context vs general activation should
  use the softmax choice rule; add regression tests for equal softmax means
  and the shared effect-prior SD

Closes #364
