### PR TITLE
fix(summary): handle single fixed-effect row in print.bmmfit summary

### DIFF
--- a/R/summary.R
+++ b/R/summary.R
@@ -87,9 +87,7 @@ print.bmmsummary <- function(x, digits = 2, color = getOption("bmm.color_summary
   }
   if (nrow(x$fixed)) {
     cat(style("green")("Regression Coefficients:\n"))
-    include <- sapply(paste0(pars_to_print, "_"), function(p) grepl(p, rownames(x$fixed)))
-    include <- apply(include, 1, any)
-    reduced <- x$fixed[include, ]
+    reduced <- .summary_fixed_rows(x$fixed, pars_to_print)
     is_constant <- is.na(reduced$Rhat)
     print_format(reduced[!is_constant, ], digits)
     cat("\n")
@@ -132,6 +130,16 @@ select_pars <- function(x) {
   model_pars <- names(x$model$parameters)
   provided_dpars <- names(x$formula)[!is_nl(x$formula)]
   union(model_pars, provided_dpars)
+}
+
+# Fixed-effect rows whose name matches any printed parameter. Uses lapply+Reduce
+# rather than sapply+apply so a single fixed-effect row or a single parameter
+# does not collapse to a dimensionless object — which broke summaries of
+# single-coefficient models such as gumbel-min sdt_ranking (dprime ~ 1).
+.summary_fixed_rows <- function(fixed, pars) {
+  patterns <- paste0(pars, "_")
+  include <- Reduce(`|`, lapply(patterns, function(p) grepl(p, rownames(fixed))))
+  fixed[include, , drop = FALSE]
 }
 
 summarise_links <- function(links) {

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -18,3 +18,21 @@ test_that("summary has reasonable outputs", {
   expect_output(print(summary1), "Links: mu = tan_half; c = log; kappa = log")
   expect_output(print(summary1), "Formula: mu = 0")
 })
+
+test_that(".summary_fixed_rows keeps a single fixed-effect row", {
+  # gumbel-min sdt_ranking has one population coefficient (dprime_Intercept) but
+  # two printed parameters (dprime, sdratio); the old sapply+apply errored here.
+  one_row <- data.frame(Estimate = 0.6, Rhat = 1, row.names = "dprime_Intercept")
+  out <- .summary_fixed_rows(one_row, c("dprime", "sdratio"))
+  expect_s3_class(out, "data.frame")
+  expect_identical(rownames(out), "dprime_Intercept")
+})
+
+test_that(".summary_fixed_rows selects all rows matching the printed parameters", {
+  fixed <- data.frame(
+    Estimate = 1:3, Rhat = c(1, NA, 1),
+    row.names = c("dprime_Intercept", "sdratio_Intercept", "nuisance_Intercept")
+  )
+  out <- .summary_fixed_rows(fixed, c("dprime", "sdratio"))
+  expect_identical(sort(rownames(out)), c("dprime_Intercept", "sdratio_Intercept"))
+})


### PR DESCRIPTION
## Summary

`summary()` errors when a fitted model has only one population-level regression coefficient. The "Regression Coefficients" block of `print.bmmsummary` selects rows with `sapply()` followed by `apply(include, 1, any)`. With a single fixed-effect row, `sapply()` simplifies to a vector, so `apply()` receives a dimensionless object and fails:

```
Regression Coefficients:
Error in apply(include, 1, any) : dim(X) must have a positive length
```

This replaces that selection with a shape-stable `Reduce("|", lapply(...))` (plus `drop = FALSE`), moved into a small unit-tested helper. Output is identical for models with several coefficient rows.

## Cause

`select_pars()` returns the union of the model parameters and the predicted parameters, e.g. `c("dprime", "sdratio")`. The printer then marks which rows of `x$fixed` match any of them:

```r
include <- sapply(paste0(pars_to_print, "_"), function(p) grepl(p, rownames(x$fixed)))
include <- apply(include, 1, any)
```

When `x$fixed` has one row, each `grepl()` returns length 1, so `sapply()` returns a length-`n_pars` vector instead of an `n_rows x n_pars` matrix, and `apply(..., 1, any)` fails. A single printed parameter collapses the same way.

## Fix

```r
.summary_fixed_rows <- function(fixed, pars) {
  patterns <- paste0(pars, "_")
  include <- Reduce(`|`, lapply(patterns, function(p) grepl(p, rownames(fixed))))
  fixed[include, , drop = FALSE]
}
```

`lapply()` always returns per-pattern logical vectors of length `nrow(fixed)`; `Reduce("|", ...)` ORs them into one vector for any row or parameter count; `drop = FALSE` keeps a single matched row a data frame.

## Tests

Two regression tests in `tests/testthat/test-summary.R` that need no fitted-model fixture (the existing summary test is gated on a real fit, which is why this slipped through): one reproduces the single-row failure, one confirms multi-parameter selection is unchanged.

## Relation to the SDT PRs

This is a general bug in core `summary.R`, so it is a standalone PR off `develop` rather than part of a model PR. The SDT model stack (`sdt_binary` ⊂ `sdt_mafc` ⊂ `sdt_ranking` ⊂ `sdt_rating`) is what exposed it. These are the first bmm models that produce a summary with a single population-level coefficient, because they fix nuisance parameters and estimate only `dprime`. For example, `sdt_ranking(dist = "gumbel_min")` and `sdt_mafc` fit as `dprime ~ 1 (+ (1 | id))`, leaving one estimated coefficient while `select_pars()` still lists `dprime` plus the fixed `sdratio`/`mu`. Earlier models always had at least two fixed rows, so the flaw never triggered.

The fix is in core code, so every model benefits (any intercept-only single-parameter fit), and the SDT branches will pick it up when rebased onto `develop` or at merge. They do not need it to build or pass their own tests; they need it only for `summary()` to print on the gumbel-min ranking and m-AFC examples.
