### PR TITLE
Fix .pwald NaN in upper tail affecting dcswald (#376)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# bmm (development version)
+
+### Bug fixes
+* Fix `.pwald()` returning `NaN`/`-Inf` in the upper tail of the shifted-Wald survival function, which propagated to `dcswald()` (and therefore `log_lik`/`posterior_predict`) for the **cswald** model at extreme reaction times. The R-side survival now uses the stable `log_diff_exp` form already used by the Stan likelihood (`swald_lccdf`) (#376).
+
 # bmm 1.3.1
 
 ### Bug fixes

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -1087,17 +1087,33 @@ validate_cswald_parameters <- function(drift, bound, ndt, zr, s) {
   if (log) log_d else exp(log_d)
 }
 
+# Stable log-space helpers mirroring the Stan functions of the same name. The
+# naive forms log(1 - exp(x)) and log(exp(a) - exp(b)) cancel catastrophically
+# near their boundaries, returning NaN/-Inf where the stable forms stay finite.
+log1m_exp <- function(x) {
+  ifelse(x > -log(2), log(-expm1(x)), log1p(-exp(x)))
+}
+
+log_diff_exp <- function(a, b) {
+  a + log1m_exp(b - a)
+}
+
 .pwald <- function(rt, drift, bound, s, lower.tail = TRUE, log.p = TRUE) {
   z1 <- (drift * rt - bound) / (s * sqrt(rt))
   z2 <- -(drift * rt + bound) / (s * sqrt(rt))
   logE <- (2 * drift * bound) / (s^2)
 
-  a1 <- pnorm(z1, log.p = TRUE)
   a2 <- logE + pnorm(z2, log.p = TRUE)
-  matrix_a <- cbind(a1, a2)
-  log_p <- apply(matrix_a, 1, matrixStats::logSumExp)
 
-  if (!lower.tail) log_p <- log(1 - exp(log_p))
+  if (lower.tail) {
+    a1 <- pnorm(z1, log.p = TRUE)
+    log_p <- apply(cbind(a1, a2), 1, matrixStats::logSumExp)
+  } else {
+    # log-survival via log_diff_exp mirrors Stan's swald_lccdf, staying finite in
+    # the upper tail where log(1 - exp(cdf)) would cancel to NaN/-Inf
+    log_p <- log_diff_exp(pnorm(z1, lower.tail = FALSE, log.p = TRUE), a2)
+  }
+
   if (log.p) log_p else exp(log_p)
 }
 

--- a/tests/testthat/test-distributions.R
+++ b/tests/testthat/test-distributions.R
@@ -723,6 +723,26 @@ test_that("pcswald and qcswald handle extreme parameters", {
   expect_true(q_small > 0.3 && q_small < 0.5)
 })
 
+test_that("dcswald error-response likelihood stays finite in the upper tail (#376)", {
+  # The simple version routes response = 0 through the shifted-Wald survival.
+  # The old naive log(1 - exp(cdf)) cancelled to NaN/-Inf for late RTs.
+  ll <- dcswald(c(5, 10, 20, 40),
+    response = 0, drift = 2, bound = 1, ndt = 0.3, version = "simple"
+  )
+  expect_true(all(is.finite(ll)))
+})
+
+test_that("dcswald error-response survival equals 1 - CDF in mid-range (#376)", {
+  rt <- c(0.4, 0.6, 0.9, 1.3)
+  ll_error <- dcswald(rt,
+    response = 0, drift = 2, bound = 1, ndt = 0.3, version = "simple"
+  )
+  cdf <- pcswald(rt,
+    response = 1, drift = 2, bound = 1, ndt = 0.3, version = "simple"
+  )
+  expect_equal(ll_error, log(1 - cdf))
+})
+
 test_that("rm3 works without providing b parameter", {
   model <- m3(
     resp_cats = c("corr", "other", "npl"),


### PR DESCRIPTION
Closes #376.

`.pwald()` computed the shifted-Wald survival with the naive `log(1 - exp(log_cdf))`, which cancels catastrophically in the upper tail and returns `NaN`/`-Inf`. Because `dcswald()` routes error responses through `.pwald(..., lower.tail = FALSE)`, `log_lik` and `posterior_predict` for the **cswald** model could silently be non-finite at extreme reaction times — even though the Stan likelihood (`swald_lccdf`) stays stable via `log_diff_exp`.

**Fix:** add internal `log1m_exp()`/`log_diff_exp()` helpers (named to match the Stan chunks) and route the `.pwald` survival branch through `log_diff_exp`, exactly as `swald_lccdf` does. The lower-tail CDF path (used by `pcswald`/`qcswald`) is unchanged and bit-identical; only the upper tail becomes finite instead of `NaN`.

**Tests:** a mid-range equality test (survival matches `log(1 - CDF)` to ~1e-16) and an upper-tail finiteness test (RTs where the old form returned `-Inf`).
