### PR TITLE
Fix substring collision in summary row selection (#379)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### Bug fixes
 * Fix `swald_lccdf()` returning incorrect log-survival probability when response time equals non-decision time in the **cswald** model. Previously returned `-Inf` instead of `0` (log of survival = 1) (#348).
+* Fix `print()` for model summaries selecting regression-coefficient rows by an unanchored substring match, so a parameter such as `a` could pull in rows of another parameter like `kappa` (e.g. in the **imm** model). Rows are now matched on the exact parameter prefix. This also fixes a crash when only a single coefficient row is shown (#379, #369).
 
 ### Other changes
 * The **ddm** model supports both `cmdstanr` and `rstan` backends. Previously, `cmdstanr` was required.

--- a/R/summary.R
+++ b/R/summary.R
@@ -87,9 +87,9 @@ print.bmmsummary <- function(x, digits = 2, color = getOption("bmm.color_summary
   }
   if (nrow(x$fixed)) {
     cat(style("green")("Regression Coefficients:\n"))
-    include <- sapply(paste0(pars_to_print, "_"), function(p) grepl(p, rownames(x$fixed)))
-    include <- apply(include, 1, any)
-    reduced <- x$fixed[include, ]
+    # match the exact parameter prefix, not a substring, so "a_" does not also
+    # select "kappa_Intercept" for models with both parameters (#379)
+    reduced <- x$fixed[sub("_.*$", "", rownames(x$fixed)) %in% pars_to_print, ]
     is_constant <- is.na(reduced$Rhat)
     print_format(reduced[!is_constant, ], digits)
     cat("\n")

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -18,3 +18,51 @@ test_that("summary has reasonable outputs", {
   expect_output(print(summary1), "Links: mu = tan_half; c = log; kappa = log")
   expect_output(print(summary1), "Formula: mu = 0")
 })
+
+# minimal bmmsummary around a real model so the print helpers run
+make_bmmsummary <- function(model, formula, fixed) {
+  structure(
+    list(
+      fixed = fixed, random = list(), ngrps = list(),
+      formula = formula, model = model,
+      data = structure(data.frame(y = 0), data_name = "d"),
+      iter = 100, warmup = 50, thin = 1, chains = 1,
+      sampler = "NUTS", algorithm = "sampling"
+    ),
+    class = "bmmsummary"
+  )
+}
+
+make_fixed <- function(rows) {
+  n <- length(rows)
+  data.frame(
+    Estimate = seq_len(n), Est.Error = rep(0.1, n),
+    "l-95% CI" = seq_len(n) - 1, "u-95% CI" = seq_len(n) + 1,
+    Rhat = rep(1, n), Bulk_ESS = rep(500, n), Tail_ESS = rep(500, n),
+    check.names = FALSE, row.names = rows
+  )
+}
+
+test_that("print.bmmsummary selects rows by exact parameter prefix (#379)", {
+  # imm has parameters a and kappa; "a_" is a substring of "kappa_", so an
+  # unanchored grepl kept rows whose true parameter is not among those printed.
+  model <- imm(
+    resp_error = "y", nt_features = "nt", nt_distances = "d",
+    set_size = "ss", version = "abc"
+  )
+  formula <- bmf(kappa ~ 1, a ~ 1, c ~ 1)
+  fixed <- make_fixed(c("kappa_Intercept", "a_Intercept", "c_Intercept", "Xa_decoy"))
+  out <- capture.output(print(make_bmmsummary(model, formula, fixed), color = FALSE))
+
+  expect_true(any(grepl("kappa_Intercept", out)))
+  expect_true(any(grepl("a_Intercept", out)))
+  expect_false(any(grepl("Xa_decoy", out)))
+})
+
+test_that("print.bmmsummary handles a single regression coefficient row (#369)", {
+  model <- sdm(resp_error = "y")
+  formula <- bmf(c ~ 1, kappa ~ 1)
+  fixed <- make_fixed("kappa_Intercept")
+  out <- capture.output(print(make_bmmsummary(model, formula, fixed), color = FALSE))
+  expect_true(any(grepl("kappa_Intercept", out)))
+})


### PR DESCRIPTION
`print.bmmsummary` picked coefficient rows with an unanchored `grepl("a_", ...)`, so `"a_"` also matched `"kappa_Intercept"` — a model with both `a` and `kappa` (e.g. imm) could keep the wrong rows. It now tokenizes the brms prefix and compares it exactly against the parameter set.

Dropping the `sapply`/`apply` step also fixes the single-row crash from #369, so both are resolved here. Printed output is unchanged for every shipping model (verified against the sdm and m3 fixtures). Added a regression test that fails under the old substring match.
