### PR TITLE
Guard against fixed parameters missing from the model formula (#377)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# bmm (development version)
+
+### Bug fixes
+* `fixed_pars_priors()` now raises a clear error when a model's `fixed_parameters` includes a parameter that is absent from the constructed formula (neither a dpar nor an nlpar). Previously it silently emitted a malformed `b_Intercept ~ constant()` prior that `brm()` rejected with a cryptic message (#377).
+
 # bmm 1.3.1
 
 ### Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # bmm (development version)
 
-### Bug fixes
-* `fixed_pars_priors()` now raises a clear error when a model's `fixed_parameters` includes a parameter that is absent from the constructed formula (neither a dpar nor an nlpar). Previously it silently emitted a malformed `b_Intercept ~ constant()` prior that `brm()` rejected with a cryptic message (#377).
+### Other changes
+* Added an internal consistency check in `configure_prior()`: if a model's `fixed_parameters` includes a parameter that its `configure_model()` never wires into the formula (neither a dpar nor an nlpar), bmm now fails with a clear model-definition error instead of letting a malformed `b_Intercept ~ constant()` prior reach `brm()`. This is a safety net for model development; it cannot be reached through the normal `bmm()` interface, where an unrecognized parameter is already caught earlier by `check_formula()` (#377).
 
 # bmm 1.3.1
 

--- a/R/helpers-prior.R
+++ b/R/helpers-prior.R
@@ -161,6 +161,12 @@ fixed_pars_priors <- function(model, formula, additional_pars = list()) {
   dpars <- names(bterms$dpars)
   nlpars <- names(bterms$nlpars)
 
+  stopif(
+    any(!pars %in% c(dpars, nlpars)),
+    "Fixed parameter(s) {collapse_comma(pars[!pars %in% c(dpars, nlpars)])} \\
+    are not part of the model formula."
+  )
+
   # flexibly set the variables for set_prior
   classes <- ifelse(pars %in% dpars, "Intercept", "b")
   coefs <- ifelse(pars %in% dpars, "", "Intercept")

--- a/R/helpers-prior.R
+++ b/R/helpers-prior.R
@@ -161,10 +161,15 @@ fixed_pars_priors <- function(model, formula, additional_pars = list()) {
   dpars <- names(bterms$dpars)
   nlpars <- names(bterms$nlpars)
 
+  # internal consistency check: a fixed parameter that configure_model never
+  # wires into the formula would collapse to a malformed b_Intercept prior
+  missing_pars <- pars[!pars %in% c(dpars, nlpars)]
   stopif(
-    any(!pars %in% c(dpars, nlpars)),
-    "Fixed parameter(s) {collapse_comma(pars[!pars %in% c(dpars, nlpars)])} \\
-    are not part of the model formula."
+    length(missing_pars) > 0,
+    "Fixed parameter(s) {collapse_comma(missing_pars)} are not part of the model \\
+    formula (neither a distributional nor a non-linear parameter). This is a \\
+    model-definition error: configure_model() must wire every fixed parameter \\
+    into the formula."
   )
 
   # flexibly set the variables for set_prior

--- a/tests/testthat/test-helpers-prior.R
+++ b/tests/testthat/test-helpers-prior.R
@@ -46,6 +46,43 @@ test_that("in combine prior, prior2 overwrites only shared components with prior
   expect_equal(dplyr::filter(prior, dpar == "kappa"), dplyr::filter(prior2, dpar == "kappa"))
 })
 
+test_that("fixed_pars_priors errors clearly when a fixed parameter is absent from the formula", {
+  model <- list(fixed_parameters = list(sdratio = 0))
+  formula <- brms::bf(y ~ 1)
+  expect_error(
+    fixed_pars_priors(model, formula),
+    "sdratio.*not part of the model formula"
+  )
+})
+
+test_that("the fixed-parameter guard fires through the full default_prior pipeline", {
+  # a fixed parameter that no configure_model wires into the formula survives
+  # check_model/check_formula reconciliation and must be caught before brms
+  model <- sdm(resp_error = "y")
+  model$fixed_parameters$sdratio <- 0
+  dat <- data.frame(y = rsdm(30, mu = 0, c = 3, kappa = 4))
+  expect_error(
+    default_prior(bmf(c ~ 1, kappa ~ 1), dat, model),
+    "sdratio.*not part of the model formula"
+  )
+})
+
+test_that("fixed_pars_priors builds constant priors for dpar and nlpar fixed parameters", {
+  dpar_prior <- fixed_pars_priors(
+    list(fixed_parameters = list(sigma = 1)),
+    brms::bf(y ~ 1, sigma ~ 1)
+  )
+  expect_equal(dpar_prior$prior, "constant(1)")
+  expect_equal(dpar_prior$dpar, "sigma")
+
+  nlpar_prior <- fixed_pars_priors(
+    list(fixed_parameters = list(b = 0)),
+    brms::bf(y ~ a + b, a ~ 1, b ~ 1, nl = TRUE)
+  )
+  expect_equal(nlpar_prior$prior, "constant(0)")
+  expect_equal(nlpar_prior$nlpar, "b")
+})
+
 test_that("no check for sort_data with default_priors function", {
   withr::local_options("bmm.sort_data" = "check")
   res <- capture_messages(default_prior(


### PR DESCRIPTION
Closes #377

`fixed_pars_priors()` classifies every fixed parameter as either a dpar or an nlpar. When a `fixed_parameters` entry is neither, the `ifelse` fallbacks collapse to `class = "b"`, `coef = "Intercept"` and it emits `b_Intercept ~ constant()` — a prior `brm()` rejects with a cryptic "does not correspond to any model parameter" error.

This is an internal consistency check, not user-facing validation. A user going through `bmm()` + `bmf()` cannot reach it: a fixed parameter that isn't a real model parameter is caught two steps earlier by `check_formula()` ("Unrecognized model parameters: ..."), and a real fixed parameter is always wired into the formula by `add_missing_parameters()` or the model's family. I checked all eight shipped models — in each, every fixed parameter ends up as a dpar or nlpar, so the guard is inert for them.

The guard only fires on a model-definition inconsistency: a constructor that declares a fixed parameter its `configure_model()` never adds to the formula. That is exactly what bit the SDT-ranking EV variant — an EV family that dropped the `sdratio` dpar while `sdratio` stayed in `fixed_parameters` — and cost a debugging session. The message is written for that audience:

> Fixed parameter(s) 'sdratio' are not part of the model formula (neither a distributional nor a non-linear parameter). This is a model-definition error: configure_model() must wire every fixed parameter into the formula.

The fix is one guard, placed after the dpar and nlpar sets are known:

```r
missing_pars <- pars[!pars %in% c(dpars, nlpars)]
stopif(length(missing_pars) > 0, "Fixed parameter(s) {...} are not part of the model formula ...")
```

It fires only on configurations that already fail today, so no working model changes.

I verified this end-to-end rather than from the isolated function. Driving `default_prior()` — the same pipeline as `bmm()` — with a stray fixed parameter shows it survives `check_model` and `check_formula`, reaches `configure_prior`, and produces the malformed `b_Intercept ~ constant(0)`. With the guard, the pipeline fails fast with the clear model-definition error instead. No false positives: default `sdm` and the case where the user frees `mu` both pass, and all model test suites stay green.

Tests: two unit tests on the guard plus a full-pipeline regression test through `default_prior()`. NEWS notes it under *Other changes* as a developer safety net.
