### PR TITLE
392 extend print bmmodel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # bmm (development version)
 
 ### Other changes
-* `print.bmmodel()` now also displays the required response variables and the default parameter links, answering "what does my data frame need to look like?" directly at the console (#392).
+* `print.bmmodel()` now also displays the required response variables (one per line, annotated with the expected coding — e.g. radians in [-pi, pi] for the circular models, seconds and 0/1 responses for the trial-wise RT models) and the default parameter links, answering "what does my data frame need to look like?" directly at the console (#392).
 
 # bmm 1.3.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# bmm (development version)
+
+### Other changes
+* `print.bmmodel()` now also displays the required response variables and the default parameter links, answering "what does my data frame need to look like?" directly at the console (#392).
+
 # bmm 1.3.1
 
 ### Bug fixes

--- a/R/helpers-model.R
+++ b/R/helpers-model.R
@@ -179,13 +179,43 @@ update_model_fixed_parameters <- function(model, formula) {
   model
 }
 
+# kept central rather than as a field in each model constructor so the console
+# annotations stay short, uniform and reviewable in one place
+response_annotations <- function(model) {
+  if (inherits(model, "circular")) {
+    return(list(resp_error = "radians in [-pi, pi]"))
+  }
+  if (inherits(model, "ddm") || inherits(model, "cswald")) {
+    return(list(
+      rt = "seconds",
+      response = "0/1 or logical; 1 = upper boundary"
+    ))
+  }
+  if (inherits(model, "ezdm")) {
+    return(list(
+      mean_rt = "seconds",
+      var_rt = "seconds^2",
+      n_upper = "count of upper-boundary responses"
+    ))
+  }
+  if (inherits(model, "m3")) {
+    return(list(resp_cats = "counts per response category"))
+  }
+  list()
+}
+
 #' @export
 print.bmmodel <- function(x, ...) {
   cat(construct_model_call(x), "\n")
+  annotations <- response_annotations(x)
   resp_str <- sapply(names(x$resp_vars), function(var) {
-    paste0(var, " = ", paste(x$resp_vars[[var]], collapse = ", "))
+    annot <- annotations[[var]]
+    paste0(
+      var, " = ", paste(x$resp_vars[[var]], collapse = ", "),
+      if (!is.null(annot)) paste0(" (", annot, ")")
+    )
   })
-  cat("Response:  ", paste(resp_str, collapse = ", "), "\n")
+  cat("Response:  ", paste(resp_str, collapse = "\n            "), "\n")
   cat("Parameters:", paste(names(x$parameters), collapse = ", "), "\n")
   if (length(x$links) > 0) {
     cat("Links:     ", summarise_links(x$links), "\n")

--- a/R/helpers-model.R
+++ b/R/helpers-model.R
@@ -182,8 +182,14 @@ update_model_fixed_parameters <- function(model, formula) {
 #' @export
 print.bmmodel <- function(x, ...) {
   cat(construct_model_call(x), "\n")
-  par_names <- names(x$parameters)
-  cat("Parameters:", paste(par_names, collapse = ", "), "\n")
+  resp_str <- sapply(names(x$resp_vars), function(var) {
+    paste0(var, " = ", paste(x$resp_vars[[var]], collapse = ", "))
+  })
+  cat("Response:  ", paste(resp_str, collapse = ", "), "\n")
+  cat("Parameters:", paste(names(x$parameters), collapse = ", "), "\n")
+  if (length(x$links) > 0) {
+    cat("Links:     ", summarise_links(x$links), "\n")
+  }
   if (length(x$fixed_parameters) > 0) {
     fixed_str <- paste(
       names(x$fixed_parameters), "=", x$fixed_parameters,

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -129,3 +129,31 @@ test_that("print.bmmodel() shows fixed parameters", {
   expect_true(any(grepl("Fixed:", out)))
   expect_true(any(grepl("mu", out)))
 })
+
+test_that("print.bmmodel() shows response variables and links", {
+  m <- sdm(resp_error = "y")
+  out <- capture.output(print(m))
+
+  expect_true(any(grepl("Response:.*resp_error = y", out)))
+  expect_true(any(grepl("Links:.*mu = tan_half; c = log; kappa = log", out)))
+})
+
+test_that("print.bmmodel() lists multiple response variables", {
+  m <- ddm(rt = "myrt", response = "myresp")
+  out <- capture.output(print(m))
+
+  expect_true(any(grepl("Response:.*rt = myrt, response = myresp", out)))
+})
+
+test_that("print.bmmodel() lists vector-valued response variables", {
+  m <- m3(
+    resp_cats = c("corr", "other", "npl"),
+    num_options = c(1, 4, 5),
+    choice_rule = "simple",
+    version = "ss"
+  )
+  out <- capture.output(print(m))
+
+  expect_true(any(grepl("Response:.*resp_cats = corr, other, npl", out)))
+  expect_true(any(grepl("Links:.*c = log; a = log", out)))
+})

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -138,11 +138,37 @@ test_that("print.bmmodel() shows response variables and links", {
   expect_true(any(grepl("Links:.*mu = tan_half; c = log; kappa = log", out)))
 })
 
-test_that("print.bmmodel() lists multiple response variables", {
+test_that("print.bmmodel() lists response variables one per line with annotations", {
   m <- ddm(rt = "myrt", response = "myresp")
   out <- capture.output(print(m))
 
-  expect_true(any(grepl("Response:.*rt = myrt, response = myresp", out)))
+  expect_true(any(grepl("Response:   rt = myrt (seconds)", out, fixed = TRUE)))
+  expect_true(any(grepl(
+    "            response = myresp (0/1 or logical; 1 = upper boundary)",
+    out,
+    fixed = TRUE
+  )))
+})
+
+test_that("print.bmmodel() shows response bounds for circular models", {
+  out <- capture.output(print(sdm(resp_error = "y")))
+
+  expect_true(any(grepl("resp_error = y (radians in [-pi, pi])", out, fixed = TRUE)))
+})
+
+test_that("print.bmmodel() annotates aggregated ezdm response variables", {
+  m <- ezdm(
+    mean_rt = "mrt", var_rt = "vrt", n_upper = "nu", n_trials = "nt"
+  )
+  out <- capture.output(print(m))
+
+  expect_true(any(grepl("mean_rt = mrt (seconds)", out, fixed = TRUE)))
+  expect_true(any(grepl("var_rt = vrt (seconds^2)", out, fixed = TRUE)))
+  expect_true(any(grepl(
+    "n_upper = nu (count of upper-boundary responses)",
+    out,
+    fixed = TRUE
+  )))
 })
 
 test_that("print.bmmodel() lists vector-valued response variables", {


### PR DESCRIPTION
Closes #392.

`print.bmmodel()` answered every console question except the most common one:
what does my data frame need to look like? This PR adds that information to the printout, which now shows the response variables with their expected coding (one per line) and the default parameter links:

```
    ddm(rt = "rt", response = "resp")
    Response:   rt = rt (seconds)
                response = resp (0/1 or logical; 1 = upper boundary)
    Parameters: drift, bound, ndt, zr
    Links:      drift = identity; bound = log; ndt = log; zr = logit
    Fixed:      zr = 0, mu = 0
    Use parameters() for more details.
```

Circular models are annotated with `(radians in [-pi, pi])`, ezdm with the aggregated-statistics coding, m3 with `(counts per response category)`. The annotations match what `check_data()` actually enforces.

Two design decisions worth a look:

- `other_vars` are not listed as data columns, because they mix real columns  with constants and options (e.g. m3's `choice_rule = "softmax"`). They  remain visible in the constructor call line, and full data requirements
  stay in the `?model` help pages.
- The annotations live in a single internal lookup (`response_annotations()`  in helpers-model.R) keyed on the existing model classes, rather than as a  new field in every constructor. A model without an entry simply print unannotated. If you would rather have this as constructor-level metadata (like `requirements`), the refactor is mechanical.

Deliberately out of scope: native-scale parameter ranges. They are fully derivable from the links, but inlining them would crowd the Links line; the better home is a `range` column in `parameters()`, which I would do as a separate small PR.

Tests added for single-, multi-, and vector-valued response variables;
`R CMD check` passes with 0 errors / 0 warnings.
