### PR TITLE
ci: cache CmdStan build across workflow runs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -73,10 +73,46 @@ jobs:
             fansi
             yaml
 
-      - name: Build Cmdstan
+      # Cache the built CmdStan so it is only compiled when a new version is
+      # released (the cache key includes the latest release version)
+      - name: Get latest CmdStan release
+        id: cmdstan-version
+        shell: bash
         run: |
-          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = parallel::detectCores())
+          tag=$(curl -sSL --retry 3 \
+            -H "Authorization: Bearer ${GITHUB_PAT}" \
+            https://api.github.com/repos/stan-dev/cmdstan/releases/latest | jq -r '.tag_name // empty')
+          if [ -z "$tag" ]; then
+            echo "Failed to determine the latest CmdStan release" >&2
+            exit 1
+          fi
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Locate CmdStan install path
+        id: cmdstan-path
+        run: |
+          cat(sprintf("path=%s\n", cmdstanr::cmdstan_default_install_path()),
+              file = Sys.getenv("GITHUB_OUTPUT"), append = TRUE)
+        shell: Rscript {0}
+
+      - name: Cache CmdStan
+        id: cmdstan-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.cmdstan-path.outputs.path }}
+          key: cmdstan-${{ runner.os }}-${{ steps.cmdstan-version.outputs.version }}
+
+      - name: Set up CmdStan toolchain
+        run: cmdstanr::check_cmdstan_toolchain(fix = TRUE)
+        shell: Rscript {0}
+
+      - name: Build CmdStan
+        if: steps.cmdstan-cache.outputs.cache-hit != 'true'
+        run: |
+          cmdstanr::install_cmdstan(
+            cores = parallel::detectCores(),
+            version = "${{ steps.cmdstan-version.outputs.version }}"
+          )
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -56,10 +56,46 @@ jobs:
             any::pkgdown
             local::.
 
-      - name: Build Cmdstan
+      # Cache the built CmdStan so it is only compiled when a new version is
+      # released (the cache key includes the latest release version)
+      - name: Get latest CmdStan release
+        id: cmdstan-version
+        shell: bash
         run: |
-          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan(cores = parallel::detectCores())
+          tag=$(curl -sSL --retry 3 \
+            -H "Authorization: Bearer ${GITHUB_PAT}" \
+            https://api.github.com/repos/stan-dev/cmdstan/releases/latest | jq -r '.tag_name // empty')
+          if [ -z "$tag" ]; then
+            echo "Failed to determine the latest CmdStan release" >&2
+            exit 1
+          fi
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Locate CmdStan install path
+        id: cmdstan-path
+        run: |
+          cat(sprintf("path=%s\n", cmdstanr::cmdstan_default_install_path()),
+              file = Sys.getenv("GITHUB_OUTPUT"), append = TRUE)
+        shell: Rscript {0}
+
+      - name: Cache CmdStan
+        id: cmdstan-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.cmdstan-path.outputs.path }}
+          key: cmdstan-${{ runner.os }}-${{ steps.cmdstan-version.outputs.version }}
+
+      - name: Set up CmdStan toolchain
+        run: cmdstanr::check_cmdstan_toolchain(fix = TRUE)
+        shell: Rscript {0}
+
+      - name: Build CmdStan
+        if: steps.cmdstan-cache.outputs.cache-hit != 'true'
+        run: |
+          cmdstanr::install_cmdstan(
+            cores = parallel::detectCores(),
+            version = "${{ steps.cmdstan-version.outputs.version }}"
+          )
         shell: Rscript {0}
 
       - name: Build site


### PR DESCRIPTION
## Summary

Every `R-CMD-check` and `pkgdown` run currently rebuilds CmdStan from source — ~2 min on ubuntu/macos and ~4 min on windows, on every push and PR. This PR caches the built CmdStan directory with `actions/cache` so it is restored in seconds on subsequent runs.

## How it works

- A step queries the GitHub API for the latest CmdStan release tag (using the job's `GITHUB_PAT` to avoid rate limits) and another asks cmdstanr for its default install path, so the cache path is correct on all three OSes (Windows `HOME` quirks included).
- The cache key is `cmdstan-<OS>-<version>`, so the cache invalidates automatically when a new CmdStan version is released — no manual version pinning to maintain.
- `install_cmdstan()` only runs on a cache miss, and is passed the queried version explicitly so the cached build always matches the key. `check_cmdstan_toolchain(fix = TRUE)` still runs on every job, since compiling Stan models during checks needs the toolchain regardless.

## Notes

- The first run on each OS (and the first after each new CmdStan release) still builds from source and saves the cache; after this merges, the push to `develop` seeds caches that all PR runs can restore.
- GitHub evicts caches unused for 7 days, but with the current CI frequency they should stay warm.
- If a runner-image toolchain bump ever breaks a cached build, delete the affected cache with `gh cache delete` (or wait for the next CmdStan release to rotate the key).
- `test-coverage` doesn't install CmdStan today, so it is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)