### PR TITLE
Add trial-to-trial non-decision-time variability (`sndt`) to `cswald` (#387)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,6 +49,7 @@ Suggests:
     mixtur,
     remotes,
     rmarkdown,
+    statmod,
     stringr,
     testthat (>= 3.0.0),
     tidybayes,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### New features
 * The **sdm** model now supports within-chain parallelization via the `threads` argument (e.g. `bmm(..., threads = 2)`), reducing fitting time by up to ~45% in benchmarks (#374).
+* The **cswald** model (both versions) gains an optional parameter `sndt` for uniform trial-to-trial variability in the non-decision time (the `st0` of rtdists): the non-decision time is `Uniform(ndt, ndt + sndt)`, so `ndt` is the minimum and `ndt + sndt/2` the mean. It is fixed at 0 by default, which reproduces the previous likelihood exactly, and is estimated by adding `sndt ~ 1` to the formula. This stops a few fast responses from biasing `ndt`, `drift`, and `bound`. `sndt` itself is weakly identified, and in the `crisk` version at substantial error rates it can absorb approximation error; see `?cswald`. `dcswald()`, `pcswald()`, `qcswald()`, and `rcswald()` gain a matching `sndt` argument (#387).
 * Add `softplus` as an opt-in link function for positively-bounded parameters, as an alternative to the default `log` link. `softplus(x) = log(1 + exp(x))` keeps parameters positive while growing linearly for large values, avoiding the numerical blow-up of `exp()` and giving predictor effects an additive (rather than multiplicative) interpretation on the natural scale. Enable it per parameter via the model's `links` list, e.g. `m3(...)$links <- list(c = "softplus", a = "softplus")` or `ddm(rt, response, links = list(bound = "softplus"))` (#363).
 
 ### Bug fixes

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -825,6 +825,11 @@ rddm <- function(n, drift, bound, ndt, zr = 0.5) {
 #'   approximation to the Wiener diffusion model for tasks with high accuracy
 #'   (few errors).
 #'
+#'   With `sndt > 0`, the `"crisk"` density gives the two accumulators
+#'   independent non-decision-time draws, whereas the rtdists-based functions
+#'   share one draw per trial, so `dcswald()` and `rcswald()` are not exact
+#'   inverses for a biased `zr`; see the section on `sndt` in [cswald()].
+#'
 #' @param rt A vector of response times in seconds for which the likelihood
 #'   should be evaluated
 #' @param response A vector of responses coded numerically: 0 = lower response,
@@ -837,6 +842,14 @@ rddm <- function(n, drift, bound, ndt, zr = 0.5) {
 #'   Default is `0.5` (unbiased). Values must be between 0 and 1.
 #' @param s The diffusion constant - the standard deviation of the noise in the
 #'   evidence accumulation process. Default is `s = 1`
+#' @param sndt The range of the trial-to-trial variability in the non-decision
+#'   time. The non-decision time is uniformly distributed on
+#'   `[ndt, ndt + sndt]`, so `ndt` is the *minimum* non-decision time and the
+#'   mean non-decision time is `ndt + sndt/2`. Default is `sndt = 0` (no
+#'   variability), which reproduces the standard censored shifted Wald model.
+#'   Corresponds to the `st0` parameter of [rtdists::rdiffusion()]. (fast-dm
+#'   uses the same name for a uniform of the same width but centers it on `t0`,
+#'   so its `t0` is the mean rather than the minimum non-decision time.)
 #' @param version A character string specifying the version of the `cswald` for
 #'   which the likelihood should be returned. Available versions are "simple"
 #'   and "crisk", the default is "simple."
@@ -859,10 +872,16 @@ rddm <- function(n, drift, bound, ndt, zr = 0.5) {
 #' dat <- rcswald(n = 1000, drift = 2, bound = 1, ndt = 0.3)
 #' head(dat)
 #' hist(dat$rt)
+#'
+#' # with uniform trial-to-trial variability in the non-decision time: ndt is
+#' # then the minimum, so the fastest responses no longer pin it
+#' dat_var <- rcswald(n = 1000, drift = 2, bound = 1, ndt = 0.3, sndt = 0.15)
+#' min(dat_var$rt) - min(dat$rt)
+#' dcswald(0.5, 1, drift = 2, bound = 1, ndt = 0.3, sndt = 0.15)
 #' @export
-dcswald <- function(rt, response, drift, bound, ndt, zr = 0.5, s = 1,
+dcswald <- function(rt, response, drift, bound, ndt, zr = 0.5, s = 1, sndt = 0,
                     version = c("simple", "crisk"), log = TRUE) {
-  validate_cswald_parameters(drift, bound, ndt, zr, s)
+  validate_cswald_parameters(drift, bound, ndt, zr, s, sndt)
   version <- match.arg(version)
 
   stopif(
@@ -872,20 +891,22 @@ dcswald <- function(rt, response, drift, bound, ndt, zr = 0.5, s = 1,
     the shortest reaction time."
   )
 
-  .dcswald(rt, response, drift, bound, ndt, zr, s, version, log)
+  .dcswald(rt, response, drift, bound, ndt, zr, s, sndt, version, log)
 }
 
-.dcswald <- function(rt, response, drift, bound, ndt, zr, s, version, log) {
+# Fits made before sndt existed store a log_lik closure that calls .dcswald()
+# without it; the default keeps those fits working
+.dcswald <- function(rt, response, drift, bound, ndt, zr, s, sndt = 0, version, log) {
   rt_shifted <- rt - ndt
 
   if (version == "simple") {
-    log_ll <- .pwald(rt_shifted, drift = drift, bound = bound, s = s, lower.tail = FALSE, log.p = TRUE)
-    ll1 <- .dwald(rt_shifted, drift = drift, bound = bound, s = s, log = TRUE)
+    log_ll <- .pwald_sndt(rt_shifted, drift, bound, s, sndt)
+    ll1 <- .dwald_sndt(rt_shifted, drift, bound, s, sndt)
   } else {
-    log_ll <- .dwald(rt_shifted, drift = -drift, bound = bound * zr, s = s, log = TRUE) +
-      .pwald(rt_shifted, drift = drift, bound = bound - bound * zr, s = s, lower.tail = FALSE, log.p = TRUE)
-    ll1 <- .dwald(rt_shifted, drift = drift, bound = bound - bound * zr, s = s, log = TRUE) +
-      .pwald(rt_shifted, drift = -drift, bound = bound * zr, s = s, lower.tail = FALSE, log.p = TRUE)
+    log_ll <- .dwald_sndt(rt_shifted, -drift, bound * zr, s, sndt) +
+      .pwald_sndt(rt_shifted, drift, bound - bound * zr, s, sndt)
+    ll1 <- .dwald_sndt(rt_shifted, drift, bound - bound * zr, s, sndt) +
+      .pwald_sndt(rt_shifted, -drift, bound * zr, s, sndt)
   }
 
   log_ll[response == 1] <- ll1[response == 1]
@@ -895,13 +916,15 @@ dcswald <- function(rt, response, drift, bound, ndt, zr = 0.5, s = 1,
 
 #' @rdname cswald_dist
 #' @export
-rcswald <- function(n, drift, bound, ndt, zr = 0.5, s = 1) {
-  validate_cswald_parameters(drift, bound, ndt, zr, s)
-  .rcswald(n, drift, bound, ndt, zr, s)
+rcswald <- function(n, drift, bound, ndt, zr = 0.5, s = 1, sndt = 0) {
+  validate_cswald_parameters(drift, bound, ndt, zr, s, sndt)
+  .rcswald(n, drift, bound, ndt, zr, s, sndt)
 }
 
-.rcswald <- function(n, drift, bound, ndt, zr, s) {
-  out <- rtdists::rdiffusion(n = n, a = bound, v = drift, t0 = ndt, z = zr * bound, s = s)
+.rcswald <- function(n, drift, bound, ndt, zr, s, sndt = 0) {
+  out <- rtdists::rdiffusion(
+    n = n, a = bound, v = drift, t0 = ndt, z = zr * bound, s = s, st0 = sndt
+  )
   data.frame(rt = out$rt, response = as.numeric(out$response == "upper"))
 }
 
@@ -933,9 +956,9 @@ rcswald <- function(n, drift, bound, ndt, zr = 0.5, s = 1) {
 #'   defined for `response = 1`. For the `"crisk"` version, this uses
 #'   [rtdists::qdiffusion()] internally.
 #' @export
-pcswald <- function(q, response, drift, bound, ndt, zr = 0.5, s = 1,
+pcswald <- function(q, response, drift, bound, ndt, zr = 0.5, s = 1, sndt = 0,
                     version = "simple", lower.tail = TRUE, log.p = FALSE) {
-  validate_cswald_parameters(drift, bound, ndt, zr, s)
+  validate_cswald_parameters(drift, bound, ndt, zr, s, sndt)
   q_shifted <- q - ndt
   p <- numeric(length(q))
 
@@ -949,11 +972,9 @@ pcswald <- function(q, response, drift, bound, ndt, zr = 0.5, s = 1,
 
     idx1 <- response == 1 & q_shifted > 0
     if (any(idx1)) {
-      p[idx1] <- .pwald(q_shifted,
-        drift = drift,
-        bound = bound, s = s,
-        lower.tail = TRUE, log.p = FALSE
-      )[idx1]
+      p[idx1] <- exp(.pwald_sndt(q_shifted, drift, bound, s, sndt,
+        lower.tail = TRUE
+      ))[idx1]
     }
 
     p[response == 0] <- NA
@@ -967,7 +988,8 @@ pcswald <- function(q, response, drift, bound, ndt, zr = 0.5, s = 1,
         v = drift,
         t0 = ndt,
         z = zr * bound,
-        s = s
+        s = s,
+        st0 = sndt
       )[idx_valid]
     }
   } else {
@@ -991,9 +1013,9 @@ pcswald <- function(q, response, drift, bound, ndt, zr = 0.5, s = 1,
 #' @rdname cswald_dist
 #' @param p A vector of probabilities for which to compute quantiles
 #' @export
-qcswald <- function(p, response, drift, bound, ndt, zr = 0.5, s = 1,
+qcswald <- function(p, response, drift, bound, ndt, zr = 0.5, s = 1, sndt = 0,
                     version = "simple", lower.tail = TRUE, log.p = FALSE) {
-  validate_cswald_parameters(drift, bound, ndt, zr, s)
+  validate_cswald_parameters(drift, bound, ndt, zr, s, sndt)
 
   if (log.p) {
     p <- exp(p)
@@ -1009,6 +1031,7 @@ qcswald <- function(p, response, drift, bound, ndt, zr = 0.5, s = 1,
   drift <- rep(drift, length.out = n)
   bound <- rep(bound, length.out = n)
   s <- rep(s, length.out = n)
+  sndt <- rep(sndt, length.out = n)
   response <- rep(response, length.out = n)
   q <- ndt # default
 
@@ -1025,15 +1048,15 @@ qcswald <- function(p, response, drift, bound, ndt, zr = 0.5, s = 1,
     # adaptive upper bound based on expected RT (mean of Wald ~ bound/drift)
     # use 20x the expected RT as upper bound, with minimum of 10 seconds
     expected_rt <- bound / max(abs(drift), 0.01)
-    upper_bound <- ndt + max(10, 20 * expected_rt)
+    upper_bound <- ndt + sndt + max(10, 20 * expected_rt)
 
     idx1 <- which(response == 1)
     for (i in idx1) {
       q[i] <- stats::uniroot(
         function(x) {
-          .pwald(x - ndt[i], drift[i], bound[i], s[i],
-            lower.tail = TRUE, log.p = FALSE
-          ) - p[i]
+          exp(.pwald_sndt(x - ndt[i], drift[i], bound[i], s[i], sndt[i],
+            lower.tail = TRUE
+          )) - p[i]
         },
         interval = c(ndt[i] + 1e-10, upper_bound[i]),
         extendInt = "upX"
@@ -1049,7 +1072,8 @@ qcswald <- function(p, response, drift, bound, ndt, zr = 0.5, s = 1,
       v = drift,
       t0 = ndt,
       z = zr * bound,
-      s = s
+      s = s,
+      st0 = sndt
     )
   } else {
     stop2(
@@ -1061,7 +1085,7 @@ qcswald <- function(p, response, drift, bound, ndt, zr = 0.5, s = 1,
   q
 }
 
-validate_cswald_parameters <- function(drift, bound, ndt, zr, s) {
+validate_cswald_parameters <- function(drift, bound, ndt, zr, s, sndt = 0) {
   stopif(
     any(bound <= 0),
     "Values for the boundary separation 'bound' must be positive."
@@ -1078,14 +1102,40 @@ validate_cswald_parameters <- function(drift, bound, ndt, zr, s) {
     any(s <= 0),
     "Values for diffusion constant 's' must be positive."
   )
+  stopif(
+    any(sndt < 0),
+    "Values for the non-decision time variability 'sndt' must be non-negative."
+  )
 }
 
 
 .dwald <- function(rt, drift, bound, s, log = TRUE) {
-  log_d <- log(bound) - 0.5 * log(2 * pi * rt^3) - log(s) -
-    (bound - drift * rt)^2 / (2 * s^2 * rt)
+  n <- max(length(rt), length(drift), length(bound), length(s))
+  rt <- rep_len(rt, n)
+  drift <- rep_len(drift, n)
+  bound <- rep_len(bound, n)
+  s <- rep_len(s, n)
+
+  # zero density before the accumulation can finish (rt is the already
+  # shifted decision time here), mirroring Stan's swald_lpdf
+  log_d <- rep(-Inf, n)
+  pos <- rt > 0
+  log_d[pos] <- log(bound[pos]) - 0.5 * log(2 * pi * rt[pos]^3) - log(s[pos]) -
+    (bound[pos] - drift[pos] * rt[pos])^2 / (2 * s[pos]^2 * rt[pos])
   if (log) log_d else exp(log_d)
 }
+
+# sndt below this is a point mass at ndt for every purpose the likelihood has;
+# the convolution is continuous there, so the plain Wald forms take over
+.sndt_min <- 1e-8
+
+# a difference of two similar numbers that falls below this fraction of them has
+# lost half of its 16-digit mantissa; what remains is noise, not a small number
+.cancellation_tol <- 1e-8
+
+# |drift| below this multiple of s^2 / bound is treated as the exact zero-drift
+# limit, where bound / drift would otherwise diverge against a vanishing bracket
+.zero_drift_tol <- 1e-6
 
 # Stable log-space helpers mirroring the Stan functions of the same name. The
 # naive forms log(1 - exp(x)) and log(exp(a) - exp(b)) cancel catastrophically
@@ -1094,27 +1144,205 @@ log1m_exp <- function(x) {
   ifelse(x > -log(2), log(-expm1(x)), log1p(-exp(x)))
 }
 
+# returns -Inf instead of NaN when rounding makes b >= a, so one underflowing
+# survivor cannot poison a whole vector of log-likelihoods
 log_diff_exp <- function(a, b) {
-  a + log1m_exp(b - a)
+  out <- a + log1m_exp(pmin(b - a, 0))
+  out[b >= a] <- -Inf
+  out
 }
 
 .pwald <- function(rt, drift, bound, s, lower.tail = TRUE, log.p = TRUE) {
-  z1 <- (drift * rt - bound) / (s * sqrt(rt))
-  z2 <- -(drift * rt + bound) / (s * sqrt(rt))
-  logE <- (2 * drift * bound) / (s^2)
+  n <- max(length(rt), length(drift), length(bound), length(s))
+  rt <- rep_len(rt, n)
+  drift <- rep_len(drift, n)
+  bound <- rep_len(bound, n)
+  s <- rep_len(s, n)
 
-  a2 <- logE + pnorm(z2, log.p = TRUE)
+  # before the accumulation can finish the CDF is 0 (survival 1),
+  # mirroring Stan's swald_lccdf
+  log_p <- rep(if (lower.tail) -Inf else 0, n)
+  pos <- rt > 0
 
-  if (lower.tail) {
-    a1 <- pnorm(z1, log.p = TRUE)
-    log_p <- apply(cbind(a1, a2), 1, matrixStats::logSumExp)
-  } else {
-    # log-survival via log_diff_exp mirrors Stan's swald_lccdf, staying finite in
-    # the upper tail where log(1 - exp(cdf)) would cancel to NaN/-Inf
-    log_p <- log_diff_exp(pnorm(z1, lower.tail = FALSE, log.p = TRUE), a2)
+  if (any(pos)) {
+    z1 <- (drift[pos] * rt[pos] - bound[pos]) / (s[pos] * sqrt(rt[pos]))
+    z2 <- -(drift[pos] * rt[pos] + bound[pos]) / (s[pos] * sqrt(rt[pos]))
+    a2 <- (2 * drift[pos] * bound[pos]) / (s[pos]^2) + stats::pnorm(z2, log.p = TRUE)
+
+    if (lower.tail) {
+      a1 <- stats::pnorm(z1, log.p = TRUE)
+      log_p[pos] <- pmax(a1, a2) + log1p(exp(-abs(a1 - a2)))
+    } else {
+      # log-survival via log_diff_exp mirrors Stan's swald_lccdf, staying finite
+      # in the upper tail where log(1 - exp(cdf)) would cancel to NaN/-Inf
+      log_p[pos] <- log_diff_exp(stats::pnorm(z1, lower.tail = FALSE, log.p = TRUE), a2)
+    }
   }
 
   if (log.p) log_p else exp(log_p)
+}
+
+# Integrated tail probabilities of the (possibly defective) Wald, both built from
+# the partial expectation M1(x) = int_0^x u f_W(u) du:
+#   lower.tail = FALSE: G(x) = int_0^x S_W(u) du = x * S_W(x) + M1(x)
+#   lower.tail = TRUE:  H(x) = int_0^x F_W(u) du = x * F_W(x) - M1(x)
+# Both are extended below zero by their limits (G(x) = x, H(x) = 0). H is formed
+# directly rather than as x - G, which would cancel wherever F_W(x) is small.
+.gwald <- function(x, drift, bound, s, lower.tail = FALSE) {
+  n <- max(length(x), length(drift), length(bound), length(s))
+  x <- rep_len(x, n)
+  drift <- rep_len(drift, n)
+  bound <- rep_len(bound, n)
+  s <- rep_len(s, n)
+
+  out <- if (lower.tail) rep(0, n) else x
+  pos <- x > 0
+  if (any(pos)) {
+    xp <- x[pos]
+    dp <- drift[pos]
+    bp <- bound[pos]
+    sp <- s[pos]
+    sqrt_x <- sqrt(xp)
+    z1 <- (dp * xp - bp) / (sp * sqrt_x)
+    z2 <- -(dp * xp + bp) / (sp * sqrt_x)
+    m1 <- (bp / dp) *
+      (stats::pnorm(z1) - exp(2 * dp * bp / sp^2 + stats::pnorm(z2, log.p = TRUE)))
+
+    # mu = bound/drift diverges as drift -> 0 while the Phi-bracket vanishes;
+    # switch to the exact drift = 0 limit to avoid the 0 * Inf cancellation
+    tiny <- abs(dp) < .zero_drift_tol * sp^2 / bp
+    if (any(tiny)) {
+      w <- bp[tiny] / (sp[tiny] * sqrt_x[tiny])
+      m1[tiny] <- 2 * bp[tiny] * (sqrt_x[tiny] * stats::dnorm(w) / sp[tiny] -
+        (bp[tiny] / sp[tiny]^2) * stats::pnorm(-w))
+    }
+
+    tail_prob <- .pwald(xp, dp, bp, sp, lower.tail = lower.tail, log.p = FALSE)
+    out[pos] <- if (lower.tail) xp * tail_prob - m1 else xp * tail_prob + m1
+  }
+  out
+}
+
+# log density of the Wald whose shift is smeared over Uniform(0, sndt):
+# f(x) = [S_W(x - sndt) - S_W(x)] / sndt (Miller et al., 2017, Eq. 6), where
+# x is the onset-shifted time rt - ndt. Entries with sndt below .sndt_min use the
+# plain Wald density (the convolution is continuous at sndt = 0); negative
+# sndt yields -Inf so the brms log_lik path rejects rather than errors.
+.dwald_sndt <- function(x, drift, bound, s, sndt) {
+  n <- max(length(x), length(drift), length(bound), length(s), length(sndt))
+  x <- rep_len(x, n)
+  drift <- rep_len(drift, n)
+  bound <- rep_len(bound, n)
+  s <- rep_len(s, n)
+  sndt <- rep_len(sndt, n)
+
+  out <- rep(-Inf, n)
+  novar <- sndt >= 0 & sndt < .sndt_min
+  conv <- sndt >= .sndt_min
+  out[novar] <- .dwald(x[novar], drift[novar], bound[novar], s[novar], log = TRUE)
+  if (any(conv)) {
+    xc <- x[conv]
+    dc <- drift[conv]
+    bc <- bound[conv]
+    sc <- s[conv]
+    snc <- sndt[conv]
+    ld <- rep(-Inf, length(xc))
+
+    # strip 0 < x <= sndt: the earlier survivor is exactly 1, so the density is
+    # F_W(x) / sndt; the log-CDF stays finite where log(1 - S) would underflow
+    strip <- xc > 0 & xc <= snc
+    ld[strip] <- .pwald(xc[strip], dc[strip], bc[strip], sc[strip],
+      lower.tail = TRUE, log.p = TRUE
+    ) - log(snc[strip])
+
+    interior <- xc > snc
+    if (any(interior)) {
+      ls_lo <- .pwald(xc[interior] - snc[interior], dc[interior], bc[interior],
+        sc[interior],
+        lower.tail = FALSE, log.p = TRUE
+      )
+      ls_hi <- .pwald(xc[interior], dc[interior], bc[interior], sc[interior],
+        lower.tail = FALSE, log.p = TRUE
+      )
+      # for defective (negative-drift) accumulators both survivors converge to
+      # the same constant in the deep tail and their difference cancels; the
+      # midpoint rule (second order in sndt) is stable there
+      fallback <- (ls_lo - ls_hi) < .cancellation_tol
+      li <- rep(-Inf, sum(interior))
+      li[!fallback] <- log_diff_exp(ls_lo[!fallback], ls_hi[!fallback]) -
+        log(snc[interior][!fallback])
+      li[fallback] <- .dwald(
+        xc[interior][fallback] - snc[interior][fallback] / 2,
+        dc[interior][fallback], bc[interior][fallback], sc[interior][fallback],
+        log = TRUE
+      )
+      ld[interior] <- li
+    }
+    out[conv] <- ld
+  }
+  out
+}
+
+# log tail probability of the Wald + Uniform(0, sndt) shift, as a difference
+# quotient of the integrated tails from .gwald():
+#   S_conv(x) = [G(x) - G(x - sndt)] / sndt      (lower.tail = FALSE)
+#   F_conv(x) = [H(x) - H(x - sndt)] / sndt      (lower.tail = TRUE)
+# Each difference cancels in its own far tail. Once it drops below
+# .cancellation_tol of its terms (a relative guard, as in .dwald_sndt), the same
+# integral is recovered by Simpson quadrature in log space, whose terms are all
+# positive and so cannot cancel.
+.pwald_sndt <- function(x, drift, bound, s, sndt, lower.tail = FALSE) {
+  n <- max(length(x), length(drift), length(bound), length(s), length(sndt))
+  x <- rep_len(x, n)
+  drift <- rep_len(drift, n)
+  bound <- rep_len(bound, n)
+  s <- rep_len(s, n)
+  sndt <- rep_len(sndt, n)
+
+  out <- rep(-Inf, n)
+  novar <- sndt >= 0 & sndt < .sndt_min
+  conv <- sndt >= .sndt_min
+  out[novar] <- .pwald(x[novar], drift[novar], bound[novar], s[novar],
+    lower.tail = lower.tail, log.p = TRUE
+  )
+  if (any(conv)) {
+    xc <- x[conv]
+    dc <- drift[conv]
+    bc <- bound[conv]
+    sc <- s[conv]
+    snc <- sndt[conv]
+
+    g_hi <- .gwald(xc, dc, bc, sc, lower.tail = lower.tail)
+    g_lo <- .gwald(xc - snc, dc, bc, sc, lower.tail = lower.tail)
+    delta <- g_hi - g_lo
+
+    fallback <- delta <= .cancellation_tol * pmax(abs(g_hi), abs(g_lo))
+    lp <- rep(-Inf, length(xc))
+    lp[!fallback] <- log(delta[!fallback] / snc[!fallback])
+    if (any(fallback)) {
+      lp[fallback] <- .simpson_log_mean(
+        xc[fallback], dc[fallback], bc[fallback], sc[fallback], snc[fallback],
+        lower.tail = lower.tail
+      )
+    }
+    out[conv] <- lp
+  }
+  out
+}
+
+# log of (1/sndt) * int_{x-sndt}^{x} P(u) du by composite Simpson on four
+# intervals, evaluated in log space
+.simpson_log_mean <- function(x, drift, bound, s, sndt, lower.tail) {
+  weights <- log(c(1, 4, 2, 4, 1) / 12)
+  nodes <- vapply(0:4, function(k) {
+    .pwald(x - sndt + k * sndt / 4, drift, bound, s,
+      lower.tail = lower.tail, log.p = TRUE
+    ) + weights[k + 1]
+  }, numeric(length(x)))
+  if (length(x) == 1) nodes <- matrix(nodes, nrow = 1)
+
+  peak <- do.call(pmax, as.data.frame(nodes))
+  peak + log(rowSums(exp(nodes - peak)))
 }
 
 

--- a/R/helpers-model.R
+++ b/R/helpers-model.R
@@ -176,6 +176,25 @@ update_model_fixed_parameters <- function(model, formula) {
   if (length(overwrite) > 0) {
     model$fixed_parameters[overwrite] <- NULL
   }
+
+  resolve_fixed_links(model)
+}
+
+# A fixed value is a constant() prior on the link scale, so a parameter fixed at
+# 0 under a log link would silently mean exp(0) = 1. A model's `links_fixed`
+# names the link to use while such a parameter stays fixed; the estimation link
+# is kept in an attribute so that freeing the parameter later restores it.
+resolve_fixed_links <- function(model) {
+  pars <- names(model$links_fixed)
+  if (length(pars) == 0) {
+    return(model)
+  }
+  estimated <- attr(model, "links_estimated") %||% model$links[pars]
+  attr(model, "links_estimated") <- estimated
+
+  model$links[pars] <- estimated[pars]
+  fixed_now <- intersect(pars, names(model$fixed_parameters))
+  model$links[fixed_now] <- model$links_fixed[fixed_now]
   model
 }
 

--- a/R/model_cswald.R
+++ b/R/model_cswald.R
@@ -158,6 +158,58 @@
 #'   For more details, see Miller et al. (2017).
 #' @param ... Additional arguments passed internally (for testing purposes).
 #' @return An object of class `bmmodel`
+#' @section Trial-to-trial variability in the non-decision time:
+#'
+#'   Both versions have an optional parameter `sndt`: the non-decision time is
+#'   `Uniform(ndt, ndt + sndt)`, so `ndt` is the *minimum* non-decision time and
+#'   `ndt + sndt/2` the mean. This is the `st0` of [rtdists::rdiffusion()];
+#'   fast-dm centers the same uniform on its `t0`, which is then the mean.
+#'
+#'   `sndt` is fixed at 0 by default, which reproduces the standard censored
+#'   shifted Wald model. Estimate it with a formula (`bmf(..., sndt ~ 1)`) or
+#'   fix it in seconds (`bmf(..., sndt = 0.15)`); fixed values are on the
+#'   natural scale, and `sndt` uses the log link only once it is estimated.
+#'
+#'   Without `sndt`, the fastest responses cap the `ndt` estimate (the
+#'   likelihood requires `ndt < min(rt)`), which biases `ndt`, `drift`, and
+#'   `bound` when the true non-decision time varies (Miller et al., 2017,
+#'   Fig. 3). Estimating `sndt` removes this bias, but `sndt` itself is weakly
+#'   identified at typical trial numbers and the prior acts as its regularizer:
+#'   estimate it at the population level only (`sndt ~ 1`) and check prior
+#'   sensitivity.
+#'
+#'   In the `"crisk"` version with `sndt > 0`, each accumulator draws its own
+#'   non-decision time instead of sharing one draw per trial. Choice
+#'   probabilities agree exactly with the shared-draw model at `zr = 0.5`; away
+#'   from it they differ by up to ~1 percentage point at `sndt = 0.3` (~4 at
+#'   `zr = 0.2`), and densities by up to ~10%. `posterior_predict()` simulates
+#'   through [rtdists::rdiffusion()], which shares the draw, so `pp_check()`
+#'   compares against a slightly different model whenever `zr` departs from 0.5.
+#'
+#' @section Estimating `sndt` in the "crisk" version at substantial error rates:
+#'
+#'   The crisk race only approximates a single diffusion process, and the
+#'   approximation degrades as errors become frequent. A free `sndt` can absorb
+#'   that approximation error rather than genuine non-decision-time
+#'   variability: on diffusion-generated data with 10-17% errors (true `bound`
+#'   1.6, `sndt` 0.2), the crisk fit converged to `bound` ~1.2 and `sndt` ~0.4
+#'   even with very large samples, while data from its own racing process were
+#'   recovered without bias. A shared-draw formulation gives the same estimates,
+#'   so this is a property of the crisk approximation itself. Options:
+#'   \itemize{
+#'     \item Below roughly 10% errors, use the `"simple"` version, where `sndt`
+#'       recovery is unbiased.
+#'     \item At substantial error rates, prefer the `ddm` model (exact, but
+#'       currently without non-decision-time variability) or keep `sndt` fixed
+#'       at 0, where the crisk estimates stay close to the diffusion values.
+#'     \item Fix `sndt` at a plausible value (e.g. `bmf(..., sndt = 0.1)`) to
+#'       bound its influence while letting the mean non-decision time exceed
+#'       the fastest response.
+#'     \item Treat a free `sndt` that comes out much larger, with a much smaller
+#'       `bound`, than in a fit with `sndt` fixed or a `ddm` fit as a sign of
+#'       absorbed approximation error, and check with `pp_check()` before
+#'       interpreting the parameters.
+#'   }
 #' @export
 #' @keywords bmmodel
 #' @seealso [dcswald()] and [rcswald()] for the density and random generation

--- a/R/model_cswald.R
+++ b/R/model_cswald.R
@@ -7,59 +7,70 @@
     parameters = list(
       drift = "drift rate",
       bound = "boundary (distance from starting point to correct boundary)",
-      ndt = "non-decision time",
-      s = "diffusion constant"
+      ndt = "non-decision time (minimum non-decision time when sndt > 0)",
+      s = "diffusion constant",
+      sndt = "range of the uniform trial-to-trial variability in the non-decision time"
     ),
     links = list(
       drift = "log",
       bound = "log",
       ndt = "log",
-      s = "log"
+      s = "log",
+      sndt = "log"
     ),
+    links_fixed = list(sndt = "identity"),
     fixed_parameters = list(
       mu = 0,
-      s = 0
+      s = 0,
+      sndt = 0
     ),
     priors = list(
       drift = list(main = "normal(0,1)", effects = "normal(0,0.3)"),
       bound = list(main = "normal(0,0.3)", effects = "normal(0,0.3)"),
       ndt = list(main = "normal(-2,0.3)", effects = "normal(0,0.3)"),
-      s = list(main = "normal(0,0.3)", effects = "normal(0,0.2)")
+      s = list(main = "normal(0,0.3)", effects = "normal(0,0.2)"),
+      sndt = list(main = "normal(-2.5,1)", effects = "normal(0,0.3)")
     ),
     init_ranges = list(
       mu = c(-0.5, 0.5),
       drift = c(1, 2),
       bound = c(1.5, 2),
       ndt = c(0.025, 0.05),
-      s = c(0.95, 1.05)
+      s = c(0.95, 1.05),
+      sndt = c(0.01, 0.05)
     )
   ),
   crisk = list(
     parameters = list(
       drift = "drift rate",
       bound = "boundary separation (total distance between boundaries)",
-      ndt = "non-decision time",
+      ndt = "non-decision time (minimum non-decision time when sndt > 0)",
       zr = "relative starting point",
-      s = "diffusion constant"
+      s = "diffusion constant",
+      sndt = "range of the uniform trial-to-trial variability in the non-decision time"
     ),
     links = list(
       drift = "identity",
       bound = "log",
       ndt = "log",
       zr = "logit",
-      s = "log"
+      s = "log",
+      sndt = "log"
     ),
+    links_fixed = list(sndt = "identity"),
     fixed_parameters = list(
       mu = 0,
       zr = 0,
-      s = 0
+      s = 0,
+      sndt = 0
     ),
     priors = list(
       drift = list(main = "normal(0,1)", effects = "normal(0,0.5)"),
       bound = list(main = "normal(0,0.3)", effects = "normal(0,0.3)"),
       ndt = list(main = "normal(-2,0.3)", effects = "normal(0,0.3)"),
       zr = list(main = "normal(0,0.3)", effects = "normal(0,0.2)"),
-      s = list(main = "normal(0,0.5)", effects = "normal(0,0.2)")
+      s = list(main = "normal(0,0.5)", effects = "normal(0,0.2)"),
+      sndt = list(main = "normal(-2.5,1)", effects = "normal(0,0.3)")
     ),
     init_ranges = list(
       mu = c(-0.5, 0.5),
@@ -67,7 +78,8 @@
       bound = c(1.5, 2),
       ndt = c(0.025, 0.05),
       zr = c(0.45, 0.55),
-      s = c(0.95, 1.05)
+      s = c(0.95, 1.05),
+      sndt = c(0.01, 0.05)
     )
   )
 )
@@ -97,6 +109,7 @@
       ),
       parameters = .cswald_version_table[[version]][["parameters"]],
       links = .cswald_version_table[[version]][["links"]],
+      links_fixed = .cswald_version_table[[version]][["links_fixed"]],
       fixed_parameters = .cswald_version_table[[version]][["fixed_parameters"]],
       default_priors = .cswald_version_table[[version]][["priors"]],
       init_ranges = .cswald_version_table[[version]][["init_ranges"]]
@@ -106,7 +119,7 @@
   )
 
   out$links[names(links)] <- links
-  out
+  resolve_fixed_links(out)
 }
 
 #' @title `r .model_cswald()$name`
@@ -121,8 +134,8 @@
 #'   automatically.
 #' @param links A named list of link functions for the model parameters.
 #'   Available parameters depend on the version: "simple" has `drift`, `bound`,
-#'   `ndt`, and `s`; "crisk" additionally has `zr`. Default links are "log" for
-#'   most parameters and "logit" for `zr`. For positive parameters, "softplus"
+#'   `ndt`, `s`, and `sndt`; "crisk" additionally has `zr`. Default links are
+#'   "log" for most parameters and "logit" for `zr`. For positive parameters, "softplus"
 #'   is available as an alternative to "log" that grows linearly for large
 #'   values and avoids the numerical blow-up of `exp()`.
 #' @param version A character string specifying which version of the cswald
@@ -315,18 +328,26 @@ bmf2bf.cswald <- function(model, formula) {
 # CONFIGURE_MODEL S3 METHODS                                             ####
 ############################################################################# !
 
+# Only sndt == 0 collapses the likelihood to the closed form the vectorized
+# (loop = FALSE) overload evaluates. Any other value, fixed or estimated, needs
+# the per-observation convolution, so the test is on the value, not on whether
+# sndt is fixed.
+#
 # brms slices Y per thread but pastes a custom family's `vars` in unsliced, so
 # under threading the family must emit "dec[start:end]" itself. start/end only
 # exist in threaded Stan code, and threading(force = TRUE) compiles threaded but
 # keeps the serial likelihood, so slice only when brms will really thread.
-cswald_decision_var <- function() {
+cswald_family_args <- function(model) {
+  if (!isTRUE(model$fixed_parameters[["sndt"]] == 0)) {
+    return(list(loop = TRUE, vars = "dec[n]"))
+  }
   threads <- getOption("brms.threads", NULL)
   # brms also accepts a bare number for this option
   if (is.numeric(threads)) {
     threads <- brms::threading(threads)
   }
   threaded <- is.list(threads) && isTRUE(threads$threads > 0) && !isTRUE(threads$force)
-  if (threaded) "dec[start:end]" else "dec"
+  list(loop = FALSE, vars = if (threaded) "dec[start:end]" else "dec")
 }
 
 #' @export
@@ -334,15 +355,17 @@ configure_model.cswald_simple <- function(model, data, formula) {
   links <- model$links
   formula <- bmf2bf(model, formula)
 
+  family_args <- cswald_family_args(model)
+
   formula$family <- brms::custom_family(
     "cswald",
-    dpars = c("mu", "drift", "bound", "ndt", "s"),
-    links = c("identity", links$drift, links$bound, links$ndt, links$s),
-    ub = c(NA, NA, NA, NA, NA),
-    lb = c(NA, 0, 0, 0, 0),
+    dpars = c("mu", "drift", "bound", "ndt", "s", "sndt"),
+    links = c("identity", links$drift, links$bound, links$ndt, links$s, links$sndt),
+    ub = c(NA, NA, NA, NA, NA, NA),
+    lb = c(NA, 0, 0, 0, 0, 0),
     type = "real",
-    vars = cswald_decision_var(),
-    loop = FALSE,
+    vars = family_args$vars,
+    loop = family_args$loop,
     log_lik = log_lik_cswald_simple,
     posterior_predict = posterior_predict_cswald_simple
   )
@@ -362,6 +385,7 @@ posterior_predict_cswald_simple <- function(i, prep, ...) {
   bound <- brms::get_dpar(prep, "bound", i = i)
   ndt <- brms::get_dpar(prep, "ndt", i = i)
   s <- brms::get_dpar(prep, "s", i = i)
+  sndt <- brms::get_dpar(prep, "sndt", i = i)
 
   # convert single-boundary bound to total separation for the full DDM generator
   out <- .rcswald(
@@ -370,7 +394,8 @@ posterior_predict_cswald_simple <- function(i, prep, ...) {
     bound = bound * 2,
     ndt = ndt,
     zr = 0.5,
-    s = s
+    s = s,
+    sndt = sndt
   )
 
   dots <- list(...)
@@ -386,11 +411,14 @@ log_lik_cswald_simple <- function(i, prep) {
   bound <- brms::get_dpar(prep, "bound", i = i)
   ndt <- brms::get_dpar(prep, "ndt", i = i)
   s <- brms::get_dpar(prep, "s", i = i)
+  sndt <- brms::get_dpar(prep, "sndt", i = i)
 
   rt <- rep(prep$data$Y[i], length(drift))
   response <- rep(prep$data$dec[i], length(drift))
 
-  .dcswald(rt, response, drift, bound, ndt, zr = 0.5, s = s, version = "simple", log = TRUE)
+  .dcswald(rt, response, drift, bound, ndt,
+    zr = 0.5, s = s, sndt = sndt, version = "simple", log = TRUE
+  )
 }
 
 #' @export
@@ -398,15 +426,20 @@ configure_model.cswald_crisk <- function(model, data, formula) {
   links <- model$links
   formula <- bmf2bf(model, formula)
 
+  family_args <- cswald_family_args(model)
+
   formula$family <- brms::custom_family(
     "cswald_crisk",
-    dpars = c("mu", "drift", "bound", "ndt", "zr", "s"),
-    links = c("identity", links$drift, links$bound, links$ndt, links$zr, links$s),
-    ub = c(NA, NA, NA, NA, 1, NA),
-    lb = c(NA, NA, 0, 0, 0, 0),
+    dpars = c("mu", "drift", "bound", "ndt", "zr", "s", "sndt"),
+    links = c(
+      "identity", links$drift, links$bound, links$ndt, links$zr, links$s,
+      links$sndt
+    ),
+    ub = c(NA, NA, NA, NA, 1, NA, NA),
+    lb = c(NA, NA, 0, 0, 0, 0, 0),
     type = "real",
-    vars = cswald_decision_var(),
-    loop = FALSE,
+    vars = family_args$vars,
+    loop = family_args$loop,
     log_lik = log_lik_cswald_crisk,
     posterior_predict = posterior_predict_cswald_crisk
   )
@@ -427,11 +460,14 @@ log_lik_cswald_crisk <- function(i, prep) {
   ndt <- brms::get_dpar(prep, "ndt", i = i)
   zr <- brms::get_dpar(prep, "zr", i = i)
   s <- brms::get_dpar(prep, "s", i = i)
+  sndt <- brms::get_dpar(prep, "sndt", i = i)
 
   rt <- rep(prep$data$Y[i], length(drift))
   response <- rep(prep$data$dec[i], length(drift))
 
-  .dcswald(rt, response, drift, bound, ndt, zr = zr, s = s, version = "crisk", log = TRUE)
+  .dcswald(rt, response, drift, bound, ndt,
+    zr = zr, s = s, sndt = sndt, version = "crisk", log = TRUE
+  )
 }
 
 posterior_predict_cswald_crisk <- function(i, prep, ...) {
@@ -440,14 +476,18 @@ posterior_predict_cswald_crisk <- function(i, prep, ...) {
   ndt <- brms::get_dpar(prep, "ndt", i = i)
   zr <- brms::get_dpar(prep, "zr", i = i)
   s <- brms::get_dpar(prep, "s", i = i)
+  sndt <- brms::get_dpar(prep, "sndt", i = i)
 
+  # rtdists shares one non-decision-time draw between the accumulators, the
+  # crisk likelihood does not; see the sndt section of ?cswald
   out <- .rcswald(
     n = length(drift),
     drift = drift,
     bound = bound,
     ndt = ndt,
     zr = zr,
-    s = s
+    s = s,
+    sndt = sndt
   )
 
   dots <- list(...)

--- a/inst/stan_chunks/cswald_crisk_functions.stan
+++ b/inst/stan_chunks/cswald_crisk_functions.stan
@@ -1,21 +1,28 @@
-// log-PDF of competing risks shifted Wald model
-real cswald_crisk_lpdf(real rt, real mu, real drift, real bound, real ndt, real zr, real s, int response) {
+// log-PDF of competing risks shifted Wald model. With sndt > 0 each accumulator
+// draws its own non-decision time; see the sndt section of ?cswald
+real cswald_crisk_lpdf(real rt, real mu, real drift, real bound, real ndt,
+                       real zr, real s, real sndt, int response) {
   // compute bounds for upper and lower response
   real bound_upper = bound - zr*bound;
   real bound_lower = zr*bound;
 
   // compute lpdf dependent on response type
   if (response == 1) {
-    return swald_lpdf(rt | drift, bound_upper, ndt, s) + swald_lccdf(rt | -drift, bound_lower, ndt, s);
+    return swald_sndt_lpdf(rt | drift, bound_upper, ndt, sndt, s)
+           + swald_sndt_lccdf(rt | -drift, bound_lower, ndt, sndt, s);
   } else {
-    return swald_lpdf(rt | -drift, bound_lower, ndt, s) + swald_lccdf(rt | drift, bound_upper, ndt, s);
+    return swald_sndt_lpdf(rt | -drift, bound_lower, ndt, sndt, s)
+           + swald_sndt_lccdf(rt | drift, bound_upper, ndt, sndt, s);
   }
 }
 
 // vectorized overload used by the loop = FALSE family: returns the summed
-// log-likelihood, winner's density plus loser's survivor per observation
+// log-likelihood, winner's density plus loser's survivor per observation.
+// sndt is unused: configure_model() selects this overload only while sndt is
+// fixed at 0, where the likelihood has this closed form
 real cswald_crisk_lpdf(vector rt, vector mu, vector drift, vector bound,
-                       vector ndt, vector zr, vector s, array[] int dec) {
+                       vector ndt, vector zr, vector s, vector sndt,
+                       array[] int dec) {
   int N = rows(rt);
   // both accumulators share rt - ndt, so a single rt <= ndt makes the winner's
   // density (and thus the summed target) -inf

--- a/inst/stan_chunks/cswald_helper_functions.stan
+++ b/inst/stan_chunks/cswald_helper_functions.stan
@@ -99,3 +99,110 @@ vector swald_log_surv_vec(vector t, vector drift, vector bound, vector sigma) {
   }
   return out;
 }
+
+// log-CDF of the shifted Wald, F_W(t) = Phi(z1) + exp(c) * Phi(z2), as a
+// log-space sum so that it stays finite deep in the left tail
+real swald_lcdf(real rt, real drift, real bound, real ndt, real sigma) {
+  real t_shifted = rt - ndt;
+  if (t_shifted <= 0) return negative_infinity();
+
+  real sigma_sqrt_t = sigma * sqrt(t_shifted);
+  real z1 = (drift * t_shifted - bound) / sigma_sqrt_t;
+  real z2 = -(drift * t_shifted + bound) / sigma_sqrt_t;
+  real log_c = 2 * bound * drift / square(sigma);
+
+  return log_sum_exp(swald_log_Phi(z1), log_c + swald_log_Phi(z2));
+}
+
+// Integrated survivor G(x) = int_0^x S_W(u) du = x * S_W(x) + M1(x), where
+// M1(x) = int_0^x u f_W(u) du is the partial expectation of the (possibly
+// defective) Wald; G(x) = x for x <= 0. Mirrors .gwald() in R/distributions.R
+real swald_gint(real x, real drift, real bound, real sigma) {
+  if (x <= 0) return x;
+
+  real sigma_sq = square(sigma);
+  real sqrt_x = sqrt(x);
+  real dx = drift * x;
+  real z1 = (dx - bound) / (sigma * sqrt_x);
+  real z2 = -(dx + bound) / (sigma * sqrt_x);
+  // q = exp(c) * Phi(z2) <= F_W(x) <= 1 mathematically, so the exp cannot
+  // overflow (same argument as in swald_log_surv)
+  real q = exp(2 * bound * drift / sigma_sq + swald_log_Phi(z2));
+  real m1;
+
+  if (abs(drift) < 1e-6 * sigma_sq / bound) {
+    // mu = bound / drift diverges as drift -> 0 while the Phi-bracket vanishes;
+    // use the exact drift = 0 limit of M1 instead of the 0 * inf cancellation
+    real w = bound / (sigma * sqrt_x);
+    m1 = 2 * bound * (sqrt_x * exp(std_normal_lpdf(w | )) / sigma
+                      - (bound / sigma_sq) * Phi(-w));
+  } else {
+    m1 = (bound / drift) * (Phi(z1) - q);
+  }
+
+  return x * exp(swald_lccdf(x | drift, bound, 0, sigma)) + m1;
+}
+
+// log of (1/sndt) * int_{x-sndt}^{x} S_W(u) du by composite Simpson on four
+// intervals in log space. Mirrors .simpson_log_mean() in R/distributions.R
+real swald_log_surv_mean(real x, real drift, real bound, real sigma, real sndt) {
+  vector[5] weights = log(to_vector({1, 4, 2, 4, 1}) / 12);
+  vector[5] terms;
+  for (k in 1:5) {
+    terms[k] = swald_lccdf(x - sndt + (k - 1) * sndt / 4 | drift, bound, 0, sigma)
+               + weights[k];
+  }
+  return log_sum_exp(terms);
+}
+
+// log-PDF of the shifted Wald with uniform trial-to-trial variability in the
+// non-decision time, NDT ~ uniform(ndt, ndt + sndt):
+// f(t) = [S_W(t - ndt - sndt) - S_W(t - ndt)] / sndt (Miller et al. 2017, Eq. 6).
+// The cutoffs 1e-8 must match .sndt_min and .cancellation_tol in
+// R/distributions.R
+real swald_sndt_lpdf(real rt, real drift, real bound, real ndt, real sndt, real sigma) {
+  if (sndt < 0) return negative_infinity();
+  // the convolution is continuous at sndt = 0, so tiny sndt takes the plain
+  // density (this is also the path for the default fixed sndt = 0)
+  if (sndt < 1e-8) return swald_lpdf(rt | drift, bound, ndt, sigma);
+
+  real t1 = rt - ndt;
+  if (t1 <= 0) return negative_infinity();
+
+  // strip ndt < rt <= ndt + sndt: the earlier survivor is exactly 1, so the
+  // density is F_W(t1) / sndt; the log-CDF stays finite where log(1 - S)
+  // would underflow
+  if (t1 <= sndt) return swald_lcdf(rt | drift, bound, ndt, sigma) - log(sndt);
+
+  real surv_early = swald_lccdf(rt | drift, bound, ndt + sndt, sigma);
+  real surv_late = swald_lccdf(rt | drift, bound, ndt, sigma);
+
+  // for defective (negative-drift) accumulators both survivors converge to the
+  // same constant in the deep tail and their difference cancels; the midpoint
+  // rule (second order in sndt) is stable there
+  if (surv_early - surv_late < 1e-8) {
+    return swald_lpdf(rt | drift, bound, ndt + sndt / 2, sigma);
+  }
+  return swald_log_diff_exp(surv_early, surv_late) - log(sndt);
+}
+
+// log survivor of the shifted Wald + uniform NDT, for censored observations:
+// S_conv(t) = [G(x1) - G(x1 - sndt)] / sndt with x1 = t - ndt. Once the
+// difference cancels (relative guard) the same integral is recovered by
+// Simpson quadrature in log space, whose terms are all positive
+real swald_sndt_lccdf(real rt, real drift, real bound, real ndt, real sndt, real sigma) {
+  if (sndt < 0) return negative_infinity();
+  if (sndt < 1e-8) return swald_lccdf(rt | drift, bound, ndt, sigma);
+
+  real x1 = rt - ndt;
+  if (x1 <= 0) return 0;
+
+  real g_hi = swald_gint(x1, drift, bound, sigma);
+  real g_lo = swald_gint(x1 - sndt, drift, bound, sigma);
+  real delta = g_hi - g_lo;
+
+  if (delta <= 1e-8 * fmax(abs(g_hi), abs(g_lo))) {
+    return swald_log_surv_mean(x1, drift, bound, sigma, sndt);
+  }
+  return log(delta / sndt);
+}

--- a/inst/stan_chunks/cswald_simple_functions.stan
+++ b/inst/stan_chunks/cswald_simple_functions.stan
@@ -1,16 +1,19 @@
 // log-PDF of the censored shifted Wald model
-real cswald_lpdf(real rt, real mu, real drift, real bound, real ndt, real s, int response) {
+real cswald_lpdf(real rt, real mu, real drift, real bound, real ndt, real s,
+                 real sndt, int response) {
   if (response == 1) {
-    return swald_lpdf(rt | drift, bound, ndt, s);
+    return swald_sndt_lpdf(rt | drift, bound, ndt, sndt, s);
   } else {
-    return swald_lccdf(rt | drift, bound, ndt, s);
+    return swald_sndt_lccdf(rt | drift, bound, ndt, sndt, s);
   }
 }
 
 // vectorized overload used by the loop = FALSE family: returns the summed
-// log-likelihood, observed responses via the density, censored via the survivor
+// log-likelihood, observed responses via the density, censored via the survivor.
+// sndt is unused: configure_model() selects this overload only while sndt is
+// fixed at 0, where the likelihood has this closed form
 real cswald_lpdf(vector rt, vector mu, vector drift, vector bound,
-                 vector ndt, vector s, array[] int dec) {
+                 vector ndt, vector s, vector sndt, array[] int dec) {
   int N = rows(rt);
   array[N] int idx1;
   array[N] int idx0;

--- a/man/cswald.Rd
+++ b/man/cswald.Rd
@@ -18,8 +18,8 @@ automatically.}
 
 \item{links}{A named list of link functions for the model parameters.
 Available parameters depend on the version: "simple" has \code{drift}, \code{bound},
-\code{ndt}, and \code{s}; "crisk" additionally has \code{zr}. Default links are "log" for
-most parameters and "logit" for \code{zr}. For positive parameters, "softplus"
+\code{ndt}, \code{s}, and \code{sndt}; "crisk" additionally has \code{zr}. Default links are
+"log" for most parameters and "logit" for \code{zr}. For positive parameters, "softplus"
 is available as an alternative to "log" that grows linearly for large
 values and avoids the numerical blow-up of \code{exp()}.}
 
@@ -75,17 +75,19 @@ for Choice Response Times. Applied Psychological Measurement, 42(2), 116-135. ht
 \itemize{
 \item \code{drift}: drift rate
 \item \code{bound}: boundary (distance from starting point to correct boundary)
-\item \code{ndt}: non-decision time
+\item \code{ndt}: non-decision time (minimum non-decision time when sndt > 0)
 \item \code{s}: diffusion constant
+\item \code{sndt}: range of the uniform trial-to-trial variability in the non-decision time
 }
 \item \strong{Fixed parameters:}
 \itemize{
 \item \code{mu} = 0
 \item \code{s} = 0
+\item \code{sndt} = 0
 }
 \item \strong{Default parameter links:}
 \itemize{
-\item drift = log; bound = log; ndt = log; s = log
+\item drift = log; bound = log; ndt = log; s = log; sndt = identity
 }
 \item \strong{Default priors:}
 \itemize{
@@ -108,6 +110,11 @@ for Choice Response Times. Applied Psychological Measurement, 42(2), 116-135. ht
 \itemize{
 \item \code{main}: normal(0,0.3)
 \item \code{effects}: normal(0,0.2)
+}
+\item \code{sndt}:
+\itemize{
+\item \code{main}: normal(-2.5,1)
+\item \code{effects}: normal(0,0.3)
 }
 }
 }

--- a/man/cswald.Rd
+++ b/man/cswald.Rd
@@ -119,6 +119,63 @@ for Choice Response Times. Applied Psychological Measurement, 42(2), 116-135. ht
 }
 }
 }
+\section{Trial-to-trial variability in the non-decision time}{
+
+
+Both versions have an optional parameter \code{sndt}: the non-decision time is
+\code{Uniform(ndt, ndt + sndt)}, so \code{ndt} is the \emph{minimum} non-decision time and
+\code{ndt + sndt/2} the mean. This is the \code{st0} of \code{\link[rtdists:Diffusion]{rtdists::rdiffusion()}};
+fast-dm centers the same uniform on its \code{t0}, which is then the mean.
+
+\code{sndt} is fixed at 0 by default, which reproduces the standard censored
+shifted Wald model. Estimate it with a formula (\code{bmf(..., sndt ~ 1)}) or
+fix it in seconds (\code{bmf(..., sndt = 0.15)}); fixed values are on the
+natural scale, and \code{sndt} uses the log link only once it is estimated.
+
+Without \code{sndt}, the fastest responses cap the \code{ndt} estimate (the
+likelihood requires \code{ndt < min(rt)}), which biases \code{ndt}, \code{drift}, and
+\code{bound} when the true non-decision time varies (Miller et al., 2017,
+Fig. 3). Estimating \code{sndt} removes this bias, but \code{sndt} itself is weakly
+identified at typical trial numbers and the prior acts as its regularizer:
+estimate it at the population level only (\code{sndt ~ 1}) and check prior
+sensitivity.
+
+In the \code{"crisk"} version with \code{sndt > 0}, each accumulator draws its own
+non-decision time instead of sharing one draw per trial. Choice
+probabilities agree exactly with the shared-draw model at \code{zr = 0.5}; away
+from it they differ by up to ~1 percentage point at \code{sndt = 0.3} (~4 at
+\code{zr = 0.2}), and densities by up to ~10\%. \code{posterior_predict()} simulates
+through \code{\link[rtdists:Diffusion]{rtdists::rdiffusion()}}, which shares the draw, so \code{pp_check()}
+compares against a slightly different model whenever \code{zr} departs from 0.5.
+}
+
+\section{Estimating \code{sndt} in the "crisk" version at substantial error rates}{
+
+
+The crisk race only approximates a single diffusion process, and the
+approximation degrades as errors become frequent. A free \code{sndt} can absorb
+that approximation error rather than genuine non-decision-time
+variability: on diffusion-generated data with 10-17\% errors (true \code{bound}
+1.6, \code{sndt} 0.2), the crisk fit converged to \code{bound} ~1.2 and \code{sndt} ~0.4
+even with very large samples, while data from its own racing process were
+recovered without bias. A shared-draw formulation gives the same estimates,
+so this is a property of the crisk approximation itself. Options:
+\itemize{
+\item Below roughly 10\% errors, use the \code{"simple"} version, where \code{sndt}
+recovery is unbiased.
+\item At substantial error rates, prefer the \code{ddm} model (exact, but
+currently without non-decision-time variability) or keep \code{sndt} fixed
+at 0, where the crisk estimates stay close to the diffusion values.
+\item Fix \code{sndt} at a plausible value (e.g. \code{bmf(..., sndt = 0.1)}) to
+bound its influence while letting the mean non-decision time exceed
+the fastest response.
+\item Treat a free \code{sndt} that comes out much larger, with a much smaller
+\code{bound}, than in a fit with \code{sndt} fixed or a \code{ddm} fit as a sign of
+absorbed approximation error, and check with \code{pp_check()} before
+interpreting the parameters.
+}
+}
+
 \examples{
 \dontshow{if (isTRUE(Sys.getenv("BMM_EXAMPLES"))) withAutoprint(\{ # examplesIf}
 # generate simulated data from the diffusion model

--- a/man/cswald_dist.Rd
+++ b/man/cswald_dist.Rd
@@ -16,11 +16,12 @@ dcswald(
   ndt,
   zr = 0.5,
   s = 1,
+  sndt = 0,
   version = c("simple", "crisk"),
   log = TRUE
 )
 
-rcswald(n, drift, bound, ndt, zr = 0.5, s = 1)
+rcswald(n, drift, bound, ndt, zr = 0.5, s = 1, sndt = 0)
 
 pcswald(
   q,
@@ -30,6 +31,7 @@ pcswald(
   ndt,
   zr = 0.5,
   s = 1,
+  sndt = 0,
   version = "simple",
   lower.tail = TRUE,
   log.p = FALSE
@@ -43,6 +45,7 @@ qcswald(
   ndt,
   zr = 0.5,
   s = 1,
+  sndt = 0,
   version = "simple",
   lower.tail = TRUE,
   log.p = FALSE
@@ -66,6 +69,15 @@ Default is \code{0.5} (unbiased). Values must be between 0 and 1.}
 
 \item{s}{The diffusion constant - the standard deviation of the noise in the
 evidence accumulation process. Default is \code{s = 1}}
+
+\item{sndt}{The range of the trial-to-trial variability in the non-decision
+time. The non-decision time is uniformly distributed on
+\verb{[ndt, ndt + sndt]}, so \code{ndt} is the \emph{minimum} non-decision time and the
+mean non-decision time is \code{ndt + sndt/2}. Default is \code{sndt = 0} (no
+variability), which reproduces the standard censored shifted Wald model.
+Corresponds to the \code{st0} parameter of \code{\link[rtdists:Diffusion]{rtdists::rdiffusion()}}. (fast-dm
+uses the same name for a uniform of the same width but centers it on \code{t0},
+so its \code{t0} is the mean rather than the minimum non-decision time.)}
 
 \item{version}{A character string specifying the version of the \code{cswald} for
 which the likelihood should be returned. Available versions are "simple"
@@ -104,6 +116,11 @@ The random generation (\code{rcswald}) and distribution functions (\code{pcswald
 theoretically consistent since the censored shifted Wald model is an
 approximation to the Wiener diffusion model for tasks with high accuracy
 (few errors).
+
+With \code{sndt > 0}, the \code{"crisk"} density gives the two accumulators
+independent non-decision-time draws, whereas the rtdists-based functions
+share one draw per trial, so \code{dcswald()} and \code{rcswald()} are not exact
+inverses for a biased \code{zr}; see the section on \code{sndt} in \code{\link[=cswald]{cswald()}}.
 }
 \details{
 \strong{Cumulative Distribution Function (\code{pcswald})}
@@ -130,6 +147,12 @@ defined for \code{response = 1}. For the \code{"crisk"} version, this uses
 dat <- rcswald(n = 1000, drift = 2, bound = 1, ndt = 0.3)
 head(dat)
 hist(dat$rt)
+
+# with uniform trial-to-trial variability in the non-decision time: ndt is
+# then the minimum, so the fastest responses no longer pin it
+dat_var <- rcswald(n = 1000, drift = 2, bound = 1, ndt = 0.3, sndt = 0.15)
+min(dat_var$rt) - min(dat$rt)
+dcswald(0.5, 1, drift = 2, bound = 1, ndt = 0.3, sndt = 0.15)
 }
 \seealso{
 \code{\link[rtdists:Diffusion]{rtdists::rdiffusion()}}, \code{\link[rtdists:Diffusion]{rtdists::pdiffusion()}},

--- a/tests/testthat/test-distributions.R
+++ b/tests/testthat/test-distributions.R
@@ -743,6 +743,344 @@ test_that("dcswald error-response survival equals 1 - CDF in mid-range (#376)", 
   expect_equal(ll_error, log(1 - cdf))
 })
 
+# ---- trial-to-trial variability in the non-decision time (sndt) ------------
+
+test_that("dcswald with sndt matches the numerical convolution (simple)", {
+  drift <- 3.5
+  bound <- 1.2
+  ndt <- 0.3
+  sndt <- 0.2
+  rt <- c(0.35, 0.45, 0.49, 0.6, 1, 2)
+  f_num <- sapply(rt, function(ti) {
+    stats::integrate(
+      function(th) exp(.dwald(ti - th, drift, bound, s = 1)) / sndt,
+      lower = ndt, upper = ndt + sndt, rel.tol = 1e-12
+    )$value
+  })
+  f_bmm <- dcswald(rt, 1, drift, bound, ndt, sndt = sndt, log = FALSE)
+  expect_equal(f_bmm, f_num, tolerance = 1e-8)
+})
+
+test_that("dcswald censored term with sndt matches the numerical integral", {
+  ndt <- 0.3
+  sndt <- 0.25
+  rt <- c(0.4, 0.6, 1, 1.8)
+  for (drift in c(2, -0.8)) {
+    bound <- if (drift > 0) 1.2 else 0.8
+    s_num <- sapply(rt, function(ti) {
+      1 - stats::integrate(
+        function(th) {
+          .pwald(ti - th, drift, bound, s = 1, lower.tail = TRUE, log.p = FALSE) / sndt
+        },
+        lower = ndt, upper = ndt + sndt, rel.tol = 1e-12
+      )$value
+    })
+    s_bmm <- exp(.pwald_sndt(rt - ndt, drift, bound, s = 1, sndt = sndt))
+    expect_equal(s_bmm, s_num, tolerance = 1e-8)
+  }
+})
+
+test_that("dcswald with sndt integrates to 1 for the simple version", {
+  total <- stats::integrate(
+    function(t) dcswald(t, 1, drift = 3.5, bound = 1.2, ndt = 0.3, sndt = 0.2, log = FALSE),
+    lower = 0.3001, upper = Inf, rel.tol = 1e-10
+  )$value
+  expect_equal(total, 1, tolerance = 1e-6)
+})
+
+test_that("dcswald crisk defective densities with sndt sum to 1", {
+  for (drift in c(0.5, 2)) {
+    total <- stats::integrate(
+      function(t) {
+        dcswald(t, 1, drift, bound = 1.6, ndt = 0.3, sndt = 0.2,
+          version = "crisk", log = FALSE
+        ) +
+          dcswald(t, 0, drift, bound = 1.6, ndt = 0.3, sndt = 0.2,
+            version = "crisk", log = FALSE
+          )
+      },
+      lower = 0.3001, upper = Inf, rel.tol = 1e-10
+    )$value
+    expect_equal(total, 1, tolerance = 1e-6)
+  }
+})
+
+test_that("dcswald with sndt covers the partial-support strip", {
+  drift <- 2
+  bound <- 1
+  ndt <- 0.3
+  sndt <- 0.2
+  # inside the strip (ndt, ndt + sndt) the density is F_W(t - ndt) / sndt
+  t_strip <- 0.4
+  expect_equal(
+    dcswald(t_strip, 1, drift, bound, ndt, sndt = sndt, log = FALSE),
+    .pwald(t_strip - ndt, drift, bound, s = 1,
+      lower.tail = TRUE, log.p = FALSE
+    ) / sndt
+  )
+  # at or below the support edge the internal density is zero
+  expect_identical(
+    .dwald_sndt(c(-0.05, 0), drift, bound, s = 1, sndt = sndt),
+    c(-Inf, -Inf)
+  )
+  # the internal survivor is 1 at or below the support edge
+  expect_identical(
+    .pwald_sndt(c(-0.05, 0), drift, bound, s = 1, sndt = sndt),
+    c(0, 0)
+  )
+})
+
+test_that(".gwald handles nonpositive x and is continuous around drift = 0", {
+  expect_identical(.gwald(c(-0.2, 0), 2, 1, 1), c(-0.2, 0))
+  # continuity of the drift ~= 0 Taylor branch against numerical integration
+  for (drift in c(0, 1e-7, -1e-7, 1e-5, -1e-5)) {
+    g_num <- stats::integrate(
+      function(u) {
+        .pwald(u, drift, 1.2, s = 1, lower.tail = FALSE, log.p = FALSE)
+      },
+      lower = 0, upper = 0.5, rel.tol = 1e-12
+    )$value
+    expect_equal(.gwald(0.5, drift, 1.2, 1), g_num, tolerance = 1e-7)
+  }
+})
+
+test_that("dcswald with sndt stays finite and monotone in the far tail", {
+  rt <- seq(5, 40, by = 5)
+  for (resp in c(0, 1)) {
+    ll <- dcswald(rt, resp, drift = 3.5, bound = 1.2, ndt = 0.3, sndt = 0.2)
+    expect_true(all(is.finite(ll)))
+    expect_true(all(diff(ll) < 0))
+  }
+  # the crisk error response evaluates a defective (negative-drift) density
+  # whose survivor difference cancels in the deep tail (midpoint fallback)
+  for (resp in c(0, 1)) {
+    ll <- dcswald(rt, resp,
+      drift = 0.5, bound = 1.6, ndt = 0.3, sndt = 0.2, version = "crisk"
+    )
+    expect_true(all(is.finite(ll)))
+    expect_true(all(diff(ll) < 0))
+  }
+})
+
+test_that(".dcswald returns -Inf for negative sndt without erroring", {
+  ll <- .dcswald(0.8, 1,
+    drift = 2, bound = 1, ndt = 0.3, zr = 0.5, s = 1, sndt = -0.1,
+    version = "simple", log = TRUE
+  )
+  expect_identical(ll, -Inf)
+})
+
+test_that("dcswald errors when rt < ndt regardless of sndt", {
+  expect_error(
+    dcswald(0.2, 1, drift = 2, bound = 1, ndt = 0.3, sndt = 0.2),
+    "smaller than the non-decision time"
+  )
+})
+
+test_that("dcswald with sndt handles draws-vector parameters mixing 0 and 0.2", {
+  sndt <- c(0, 0.2, 0, 0.2)
+  drift <- c(2, 2, 3, 3)
+  ll <- dcswald(0.8, 1, drift, bound = 1, ndt = 0.3, sndt = sndt)
+  expect_length(ll, 4)
+  expect_equal(ll[1], dcswald(0.8, 1, 2, 1, 0.3))
+  expect_equal(ll[2], dcswald(0.8, 1, 2, 1, 0.3, sndt = 0.2))
+  expect_equal(ll[4], dcswald(0.8, 1, 3, 1, 0.3, sndt = 0.2))
+})
+
+test_that("rcswald with sndt generates valid output", {
+  set.seed(123)
+  dat0 <- rcswald(5000, drift = 2, bound = 1.5, ndt = 0.3)
+  dat1 <- rcswald(5000, drift = 2, bound = 1.5, ndt = 0.3, sndt = 0.3)
+  expect_true(all(dat1$rt > 0.3))
+  # onset convention: mean NDT is ndt + sndt/2, shifting the mean RT
+  expect_equal(mean(dat1$rt) - mean(dat0$rt), 0.15, tolerance = 0.05)
+})
+
+test_that("dcswald with sndt stays finite deep in the strip (rt just above ndt)", {
+  # log(1 - S) underflows here, but the true log density ~ -bound^2 / (2 s^2 t1)
+  # is representable and must be reached through the log-CDF
+  t1 <- c(1e-3, 5e-4, 1e-4, 1e-5)
+  ll <- dcswald(0.3 + t1, 1, drift = 2, bound = 1, ndt = 0.3, sndt = 0.15)
+  expect_true(all(is.finite(ll)))
+  expect_true(all(diff(ll) < 0))
+  leading_order <- -1 / (2 * t1) - log(0.15)
+  expect_lt(max(abs(ll - leading_order) / abs(leading_order)), 0.02)
+})
+
+test_that("dcswald with sndt is the derivative of pcswald in the strip and beyond", {
+  # ndt = 0.3, sndt = 0.15 -> the strip is (0.30, 0.45)
+  q <- c(0.35, 0.40, 0.44, 0.5, 0.8, 1.2)
+  eps <- 1e-6
+  cdf_slope <- (pcswald(q + eps, 1, 2, 1, 0.3, sndt = 0.15) -
+    pcswald(q - eps, 1, 2, 1, 0.3, sndt = 0.15)) / (2 * eps)
+  dens <- dcswald(q, 1, 2, 1, 0.3, sndt = 0.15, log = FALSE)
+  expect_equal(cdf_slope, dens, tolerance = 1e-5)
+})
+
+test_that("dcswald with sndt is continuous across the strip boundary", {
+  eps <- 1e-9
+  expect_equal(
+    dcswald(0.45 - eps, 1, 2, 1, 0.3, sndt = 0.15),
+    dcswald(0.45 + eps, 1, 2, 1, 0.3, sndt = 0.15),
+    tolerance = 1e-6
+  )
+})
+
+test_that("log_diff_exp returns -Inf instead of NaN when b >= a", {
+  expect_identical(log_diff_exp(-5, -5), -Inf)
+  expect_identical(log_diff_exp(-6, -5), -Inf)
+  expect_equal(log_diff_exp(0, -1), log(1 - exp(-1)))
+  expect_equal(
+    log_diff_exp(c(0, -5, -6), c(-1, -5, -5)),
+    c(log(1 - exp(-1)), -Inf, -Inf)
+  )
+})
+
+test_that("pcswald and qcswald are inverses with sndt", {
+  p <- c(0.1, 0.25, 0.5, 0.75, 0.9)
+  q <- qcswald(p, 1, drift = 2, bound = 1, ndt = 0.3, sndt = 0.2)
+  p_back <- pcswald(q, 1, drift = 2, bound = 1, ndt = 0.3, sndt = 0.2)
+  expect_equal(p_back, p, tolerance = 1e-4)
+})
+
+test_that("cswald parameter validation works for sndt", {
+  expect_error(
+    dcswald(0.8, 1, drift = 2, bound = 1, ndt = 0.3, sndt = -0.1),
+    "must be non-negative"
+  )
+  expect_error(
+    rcswald(10, drift = 2, bound = 1, ndt = 0.3, sndt = -0.1),
+    "must be non-negative"
+  )
+  expect_error(
+    pcswald(0.8, 1, drift = 2, bound = 1, ndt = 0.3, sndt = -0.1),
+    "must be non-negative"
+  )
+  expect_error(
+    qcswald(0.5, 1, drift = 2, bound = 1, ndt = 0.3, sndt = -0.1),
+    "must be non-negative"
+  )
+  expect_silent(dcswald(0.8, 1, drift = 2, bound = 1, ndt = 0.3, sndt = 0))
+})
+
+test_that("dcswald with sndt = 0 matches an independent inverse-Gaussian density", {
+  skip_if_not_installed("statmod")
+
+  # reference outside bmm: the shifted Wald is an inverse Gaussian with mean
+  # bound/drift and shape (bound/s)^2, evaluated at rt - ndt
+  drift <- 2
+  bound <- 1.2
+  ndt <- 0.25
+  s <- 0.8
+  rt <- ndt + c(0.05, 0.2, 0.5, 1, 3)
+
+  expect_equal(
+    dcswald(rt, 1, drift, bound, ndt, s = s, version = "simple"),
+    statmod::dinvgauss(rt - ndt,
+      mean = bound / drift, shape = (bound / s)^2, log = TRUE
+    )
+  )
+})
+
+test_that("the sndt convolution is continuous across the point-mass cutoff", {
+  # below .sndt_min the plain Wald forms take over; the two branches must meet
+  args <- list(0.7, 1, drift = 2, bound = 1, ndt = 0.3, version = "simple")
+  expect_equal(
+    do.call(dcswald, c(args, sndt = 1e-9)),
+    do.call(dcswald, c(args, sndt = 1e-7)),
+    tolerance = 1e-6
+  )
+  args0 <- list(0.7, 0, drift = 2, bound = 1, ndt = 0.3, version = "simple")
+  expect_equal(
+    do.call(dcswald, c(args0, sndt = 1e-9)),
+    do.call(dcswald, c(args0, sndt = 1e-7)),
+    tolerance = 1e-6
+  )
+})
+
+test_that(".gwald splits the identity G + H = x and matches quadrature", {
+  x <- c(-0.5, 0.01, 0.1, 0.5, 1, 5)
+  drift <- 2
+  bound <- 1
+  s <- 0.4
+
+  g <- .gwald(x, drift, bound, s, lower.tail = FALSE)
+  h <- .gwald(x, drift, bound, s, lower.tail = TRUE)
+  expect_equal(g + h, x)
+
+  # H is the integrated CDF, formed directly so the lower tail keeps its digits
+  for (xi in c(0.05, 0.3, 1.5)) {
+    reference <- stats::integrate(
+      function(u) .pwald(u, drift, bound, s, lower.tail = TRUE, log.p = FALSE),
+      0, xi,
+      rel.tol = 1e-12
+    )$value
+    expect_equal(.gwald(xi, drift, bound, s, lower.tail = TRUE), reference,
+      tolerance = 1e-8
+    )
+  }
+})
+
+test_that("the sndt survivor stays smooth and accurate deep in the tail", {
+  # the two integrated survivors nearly cancel here (log S < -25); the result
+  # must still be accurate, monotone and smooth
+  drift <- 3
+  bound <- 1
+  s <- 0.4
+  sndt <- 0.1
+  x <- seq(1.60, 1.80, by = 0.01)
+
+  log_surv <- .pwald_sndt(x, drift, bound, s, sndt)
+  reference <- vapply(x, function(xi) {
+    log(stats::integrate(
+      function(u) .pwald(xi - u, drift, bound, s, lower.tail = FALSE, log.p = FALSE),
+      0, sndt,
+      rel.tol = 1e-12
+    )$value / sndt)
+  }, numeric(1))
+
+  expect_true(all(log_surv < -25))
+  expect_true(all(diff(log_surv) < 0))
+  expect_equal(log_surv, reference, tolerance = 1e-4)
+  expect_lt(max(abs(diff(diff(log_surv)))), 1e-3)
+})
+
+test_that("the sndt CDF resolves probabilities that 1 - survivor rounds away", {
+  drift <- 3
+  bound <- 1
+  s <- 0.4
+  sndt <- 0.1
+  x <- c(0.02, 0.03, 0.05)
+
+  cdf <- exp(.pwald_sndt(x, drift, bound, s, sndt, lower.tail = TRUE))
+  reference <- vapply(x, function(xi) {
+    stats::integrate(
+      function(u) .pwald(xi - u, drift, bound, s, lower.tail = TRUE, log.p = FALSE),
+      0, min(sndt, xi),
+      rel.tol = 1e-12
+    )$value / sndt
+  }, numeric(1))
+
+  expect_equal(cdf, reference, tolerance = 1e-5)
+  # 1 - survivor is exactly 0 here, so the CDF cannot be formed that way
+  expect_true(all(1 - exp(.pwald_sndt(x, drift, bound, s, sndt)) == 0))
+})
+
+test_that("pcswald and qcswald round-trip for the crisk version with sndt", {
+  p <- c(0.2, 0.5, 0.8)
+  args <- list(
+    drift = 1.5, bound = 1.4, ndt = 0.25, zr = 0.45, s = 1, sndt = 0.15,
+    version = "crisk"
+  )
+
+  q <- do.call(qcswald, c(list(p, 1), args))
+  expect_true(all(is.finite(q)))
+  expect_true(all(q > args$ndt))
+  # the crisk quantile inverts through rtdists' own numerical routine, which
+  # sets the achievable precision here
+  expect_equal(do.call(pcswald, c(list(q, 1), args)), p, tolerance = 1e-3)
+})
+
 test_that("rm3 works without providing b parameter", {
   model <- m3(
     resp_cats = c("corr", "other", "npl"),

--- a/tests/testthat/test-helpers-model.R
+++ b/tests/testthat/test-helpers-model.R
@@ -531,3 +531,27 @@ test_that("find_matching_brace handles lots of braces", {
   x <- paste0("{", strrep("{}", 100), "}")
   expect_equal(find_matching_brace(x, 1L), nchar(x))
 })
+
+test_that("resolve_fixed_links switches a parameter's link while it is fixed", {
+  model <- structure(
+    list(
+      parameters = list(a = "a", b = "b"),
+      links = list(a = "log", b = "log"),
+      links_fixed = list(b = "identity"),
+      fixed_parameters = list(b = 0)
+    ),
+    class = "bmmodel"
+  )
+
+  fixed <- resolve_fixed_links(model)
+  expect_equal(fixed$links$b, "identity")
+  expect_equal(fixed$links$a, "log")
+
+  freed <- update_model_fixed_parameters(fixed, bmf(a ~ 1, b ~ 1))
+  expect_null(freed$fixed_parameters$b)
+  expect_equal(freed$links$b, "log")
+
+  refixed <- update_model_fixed_parameters(freed, bmf(a ~ 1, b = 0))
+  expect_equal(refixed$fixed_parameters$b, 0)
+  expect_equal(refixed$links$b, "identity")
+})

--- a/tests/testthat/test-model_cswald.R
+++ b/tests/testthat/test-model_cswald.R
@@ -439,21 +439,21 @@ compile_cswald_parity_model <- function(version) {
   crisk <- version == "crisk"
   lpdf <- if (crisk) "cswald_crisk_lpdf" else "cswald_lpdf"
   scalar_args <- if (crisk) {
-    "mu[n], drift[n], bound[n], ndt[n], zr[n], s[n], dec[n]"
+    "mu[n], drift[n], bound[n], ndt[n], zr[n], s[n], sndt[n], dec[n]"
   } else {
-    "mu[n], drift[n], bound[n], ndt[n], s[n], dec[n]"
+    "mu[n], drift[n], bound[n], ndt[n], s[n], sndt[n], dec[n]"
   }
   vector_args <- if (crisk) {
-    "mu, drift, bound, ndt, zr, s, dec"
+    "mu, drift, bound, ndt, zr, s, sndt, dec"
   } else {
-    "mu, drift, bound, ndt, s, dec"
+    "mu, drift, bound, ndt, s, sndt, dec"
   }
   code <- glue(
     "functions {{\n{chunk('cswald_helper_functions.stan')}\n",
     "{chunk(paste0('cswald_', version, '_functions.stan'))}\n}}\n",
     "data {{\n  int N;\n  vector[N] rt;\n  array[N] int dec;\n  vector[N] mu;\n",
     "  vector[N] drift;\n  vector[N] bound;\n  vector[N] ndt;\n  vector[N] s;\n",
-    "  vector<lower=0,upper=1>[N] zr;\n}}\n",
+    "  vector<lower=0,upper=1>[N] zr;\n  vector<lower=0>[N] sndt;\n}}\n",
     "generated quantities {{\n",
     "  real lp_vector = {lpdf}(rt | {vector_args});\n",
     "  vector[N] lp_scalar;\n",
@@ -468,7 +468,7 @@ compile_cswald_parity_model <- function(version) {
 # observations in the two regimes where the survivor leaves its vectorized
 # probability-space path: 2*bound*drift/s^2 in the hundreds, and the deep tail
 # where Phi(-z1) underflows to 0
-cswald_parity_data <- function(n = 200) {
+cswald_parity_data <- function(n = 200, sndt = 0) {
   drift <- runif(n, 0.5, 4)
   bound <- runif(n, 0.5, 2)
   ndt <- runif(n, 0.05, 0.2)
@@ -491,7 +491,8 @@ cswald_parity_data <- function(n = 200) {
     bound = c(bound, bound_ext),
     ndt = c(ndt, ndt_ext),
     s = c(runif(n, 0.7, 1.3), runif(30, 0.9, 1.1)),
-    zr = c(runif(n, 0.2, 0.8), runif(30, 0.3, 0.7))
+    zr = c(runif(n, 0.2, 0.8), runif(30, 0.3, 0.7)),
+    sndt = rep(sndt, n + 30)
   )
 }
 
@@ -504,20 +505,81 @@ test_that("the vectorized cswald likelihood matches the scalar and R versions", 
   )
 
   for (version in c("simple", "crisk")) {
-    sdata <- cswald_parity_data()
-    fit <- compile_cswald_parity_model(version)$sample(
-      data = sdata, chains = 1, iter_sampling = 1, fixed_param = TRUE,
-      refresh = 0, show_messages = FALSE, sig_figs = 18, seed = 1
-    )
-    lp_vector <- as.numeric(fit$draws("lp_vector", format = "draws_matrix")[1, 1])
-    lp_scalar <- as.numeric(fit$draws("lp_scalar", format = "draws_matrix")[1, ])
-    lp_r <- with(sdata, .dcswald(rt, dec, drift, bound, ndt, zr, s,
-      version = version, log = TRUE
-    ))
+    model <- compile_cswald_parity_model(version)
+    # sndt = 0 is the closed form the vectorized overload evaluates; sndt > 0
+    # exercises the convolution, including the strip where rt - ndt < sndt
+    for (sndt in c(0, 0.1, 0.3)) {
+      sdata <- cswald_parity_data(sndt = sndt)
+      fit <- model$sample(
+        data = sdata, chains = 1, iter_sampling = 1, fixed_param = TRUE,
+        refresh = 0, show_messages = FALSE, sig_figs = 18, seed = 1
+      )
+      lp_vector <- as.numeric(fit$draws("lp_vector", format = "draws_matrix")[1, 1])
+      lp_scalar <- as.numeric(fit$draws("lp_scalar", format = "draws_matrix")[1, ])
+      lp_r <- with(sdata, .dcswald(rt, dec, drift, bound, ndt, zr, s, sndt,
+        version = version, log = TRUE
+      ))
 
-    # the vectorized overload is what brms compiles; it must reproduce the scalar
-    # likelihood it replaced, and the R mirror used by log_lik()
-    expect_equal(lp_vector, sum(lp_scalar), tolerance = 1e-10)
-    expect_equal(lp_scalar, lp_r, tolerance = 1e-10)
+      # the scalar overload is what brms compiles once sndt is in play; it must
+      # match the R mirror used by log_lik()
+      expect_equal(lp_scalar, lp_r, tolerance = 1e-8)
+      # the vectorized overload is what brms compiles at sndt = 0; it must
+      # reproduce the scalar likelihood it replaced
+      if (sndt == 0) expect_equal(lp_vector, sum(lp_scalar), tolerance = 1e-10)
+    }
   }
+})
+
+# -----------------------------------------------------------------------------
+# sndt: link resolution and family selection
+# -----------------------------------------------------------------------------
+
+test_that("cswald reports the link sndt is actually fixed on, and restores it", {
+  model <- cswald(rt = "rt", response = "response")
+
+  # a fixed value is a constant() on the link scale, so sndt = 0 is only
+  # sndt = 0 under an identity link (s = 0 under its log link means s = 1)
+  expect_equal(model$fixed_parameters$sndt, 0)
+  expect_equal(model$links$sndt, "identity")
+  expect_equal(model$links$s, "log")
+
+  freed <- update_model_fixed_parameters(
+    model, bmf(drift ~ 1, bound ~ 1, ndt ~ 1, sndt ~ 1)
+  )
+  expect_null(freed$fixed_parameters$sndt)
+  expect_equal(freed$links$sndt, "log")
+
+  refixed <- update_model_fixed_parameters(
+    freed, bmf(drift ~ 1, bound ~ 1, ndt ~ 1, sndt = 0)
+  )
+  expect_equal(refixed$links$sndt, "identity")
+})
+
+test_that("a fixed sndt reaches the likelihood on the natural scale", {
+  dat <- cswald_data()
+  model <- cswald(rt = "rt", response = "response")
+  formula <- bmf(drift ~ 1, bound ~ 1, ndt ~ 1, sndt = 0.15)
+
+  model <- check_model(model, dat, formula)
+  config <- configure_model(model, dat, check_formula(model, dat, formula))
+  prior <- configure_prior(model, dat, config$formula, NULL)
+
+  # constant(0.15), not constant(log(0.15)) and not exp(0.15)
+  expect_true(any(grepl("constant(0.15)", prior$prior, fixed = TRUE)))
+  expect_equal(config$formula$family$link_sndt, "identity")
+})
+
+test_that("the vectorized family is chosen by the value of sndt, not its fixedness", {
+  dat <- cswald_data()
+  model <- cswald(rt = "rt", response = "response")
+  configure <- function(f) {
+    m <- check_model(model, dat, f)
+    configure_model(m, dat, check_formula(m, dat, f))$formula$family
+  }
+
+  # only sndt == 0 collapses the likelihood to the closed form the vectorized
+  # overload evaluates; a non-zero constant is still a convolution
+  expect_false(configure(bmf(drift ~ 1, bound ~ 1, ndt ~ 1))$loop)
+  expect_true(configure(bmf(drift ~ 1, bound ~ 1, ndt ~ 1, sndt = 0.15))$loop)
+  expect_true(configure(bmf(drift ~ 1, bound ~ 1, ndt ~ 1, sndt ~ 1))$loop)
 })


### PR DESCRIPTION
Third and final PR of the cswald stack (#399 → #400 → this); base branch `cswald-vectorized`. Closes #387.

## What changes

Both cswald versions gain an optional parameter `sndt` for uniform trial-to-trial variability in the non-decision time: the non-decision time is `Uniform(ndt, ndt + sndt)`, so `ndt` is the minimum and `ndt + sndt/2` the mean (rtdists' `st0`). It is fixed at 0 by default, which reproduces the previous likelihood exactly. Without it, a handful of fast responses caps the entire `ndt` estimate and biases `ndt`, `drift`, and `bound` (Miller et al., 2017, Fig. 3). In a 3000-trial recovery on rtdists-generated data with `st0 = 0.2`, fixing `sndt = 0` produced credible intervals for `drift` and `bound` that exclude the truth; estimating it recovered all four parameters.

Two design decisions worth a look:

1. **The link a parameter uses while fixed.** A fixed value is a `constant()` prior on the link scale, so `sndt = 0` under the log link would silently mean 1 second. A model can now declare `links_fixed`; `update_model_fixed_parameters()` resolves it into `model$links` whenever the parameter is fixed and restores the estimation link when a formula frees it. `parameters()`, `print()`, `summary()` and the help page therefore report the link that is in effect.
2. **The family is chosen by the value of `sndt`, not by whether it is fixed.** Only `sndt == 0` collapses to the closed form the vectorized overload evaluates; any other value, fixed or estimated, needs the per-observation convolution and gets the `loop = TRUE` family.

## How to read it (one commit each)

1. `R/helpers-model.R`: `resolve_fixed_links()`, the `links_fixed` mechanism, with a unit test on a minimal model object.
2. `R/distributions.R`: the R side. `.dwald_sndt()` is the closed-form survivor difference (Miller et al., 2017, Eq. 6). `.pwald_sndt()` integrates the survivor over the window through the partial expectation of the Wald (`.gwald()`); where that difference cancels in the far tail, a relative guard switches to Simpson quadrature in log space. The integrated CDF is formed from the same partial expectation rather than as `1 - survivor`. `dcswald()`, `pcswald()`, `qcswald()`, `rcswald()` gain `sndt`.
3. `inst/stan_chunks/`: the Stan mirror (`swald_lcdf`, `swald_gint`, `swald_log_surv_mean`, `swald_sndt_lpdf`, `swald_sndt_lccdf`), and `R/model_cswald.R`: `sndt` in the version table with `links_fixed = identity`, `cswald_family_args()` for the family choice, `log_lik`/`posterior_predict` passing it through.
4. `R/model_cswald.R` roxygen and `NEWS.md`: two help-page sections (the convention and how to use it; the crisk caveat).

## What to verify where

- R against an implementation outside bmm: `dcswald()` at `sndt = 0` equals `statmod::dinvgauss()`.
- R against quadrature: density and censored term against `stats::integrate()`, densities integrate to 1 (both versions), the strip `ndt < rt < ndt + sndt`, the point-mass cutoff, deep-tail smoothness (`log S < -25`), lower-tail CDF where `1 - S` rounds to 0, p/q round trips.
- Stan against R: the CmdStan parity test runs the scalar overload against `.dcswald()` for `sndt ∈ {0, 0.1, 0.3}` (1e-8) and the vectorized overload against the scalar one at `sndt = 0` (1e-10).
- Model wiring: `sndt` reaches the likelihood as `constant(0.15)` on the identity link; the family switches on the value of `sndt`; the link is restored when `sndt` is freed.

## Caveats documented in `?cswald`

`sndt` is weakly identified at typical trial numbers; its value is in de-biasing the other parameters. In the crisk version each accumulator draws its own non-decision time (rtdists shares one draw per trial), and at substantial error rates a free `sndt` can absorb the crisk-vs-diffusion approximation error; the help page lists the options.

## Numbers behind the design (not in NEWS, since the code never shipped)

The survivor's cancellation guard is relative rather than absolute: an absolute floor let roughly 660 nats of corrupted values through before firing, and the log-survivor was non-monotone at 5 of 21 grid points. With the relative guard and Simpson recovery the maximum error against quadrature is ~0.001 nats (was ~0.7).

`devtools::check()`: 0 errors, 0 warnings, 1 pre-existing note (`CLAUDE.md` at top level). Full suite with `NOT_CRAN=true`: 1579 pass, 0 fail, 0 error, 1 skip (the parity test runs).
